### PR TITLE
Fix debugger views state persistence on tab switching

### DIFF
--- a/docs/user_experience_analysis.md
+++ b/docs/user_experience_analysis.md
@@ -13,8 +13,9 @@ This document tracks UX/UI enhancements for Apple1JS, focusing on authentic emul
 **Why it mattered**: Previously, colors and spacing were hardcoded throughout components, making theme changes impossible and creating visual inconsistency.
 
 **Key components**:
+
 - `MetricCard`: Standardized data display cards
-- `RegisterRow`: Consistent register visualization  
+- `RegisterRow`: Consistent register visualization
 - Design tokens in `src/styles/tokens.ts`
 - Typography scale for visual hierarchy
 
@@ -23,6 +24,7 @@ This document tracks UX/UI enhancements for Apple1JS, focusing on authentic emul
 **Advanced CRT Effects**: Authentic phosphor persistence, bloom, and barrel distortion.
 
 **Technical implementation**:
+
 - Phosphor decay: 150ms CSS transitions
 - Bloom: Radial gradient overlays
 - Barrel distortion: CSS transforms
@@ -33,11 +35,13 @@ This document tracks UX/UI enhancements for Apple1JS, focusing on authentic emul
 **Problem solved**: Initial debugger crammed everything into one view - users complained "too compressed".
 
 **Solution implemented**:
+
 - **DebuggerLayout**: Tabbed interface (Overview/Memory/Disassembly)
 - **MemoryViewer**: 768-byte hex view with address navigation
 - **StackViewer**: Real-time 6502 stack monitor ($0100-$01FF)
 
 **Key learnings**:
+
 - Users need focused views, not information density
 - Consistent navigation patterns matter (address input like disassembler)
 - Smart scrolling improves navigation (up=bottom, down=top)
@@ -55,7 +59,8 @@ This document tracks UX/UI enhancements for Apple1JS, focusing on authentic emul
 - [ ] Run-to-cursor in disassembler
 - [ ] Conditional breakpoints (e.g., "break when A=$FF")
 
-**Implementation notes**: 
+**Implementation notes**:
+
 - Worker messages exist: STEP, SET_BREAKPOINT
 - Need UI integration in DebuggerLayout
 - Store breakpoints in worker for performance
@@ -65,12 +70,14 @@ This document tracks UX/UI enhancements for Apple1JS, focusing on authentic emul
 **Why critical**: Finding specific data in 64KB is tedious without search.
 
 **Tasks**:
+
 - [ ] Search for bytes/ASCII strings
 - [ ] Highlight results in MemoryViewer
 - [ ] Navigate between matches
 - [ ] Memory write support (UI ready, needs worker)
 
 **Implementation approach**:
+
 - Add search bar to MemoryViewer
 - Use worker for efficient searching
 - Maintain result indices for navigation
@@ -80,6 +87,7 @@ This document tracks UX/UI enhancements for Apple1JS, focusing on authentic emul
 **Why useful**: Monitor specific values without constantly navigating.
 
 **Tasks**:
+
 - [ ] Add/remove watch expressions
 - [ ] Support memory addresses and registers
 - [ ] Update values in real-time
@@ -89,6 +97,7 @@ This document tracks UX/UI enhancements for Apple1JS, focusing on authentic emul
 ### Audio Package
 
 **Quick wins for authenticity**:
+
 - [ ] Keyboard click sounds (mechanical switches)
 - [ ] System beeps for errors
 - [ ] Volume controls
@@ -98,6 +107,7 @@ This document tracks UX/UI enhancements for Apple1JS, focusing on authentic emul
 ### Visual Enhancements
 
 **Complete the vintage experience**:
+
 - [ ] Power-on sequence (degauss animation)
 - [ ] Activity LEDs for I/O operations
 - [ ] Phosphor burn-in simulation
@@ -105,6 +115,7 @@ This document tracks UX/UI enhancements for Apple1JS, focusing on authentic emul
 ### Cassette Interface
 
 **Preserve software history**:
+
 - [ ] Audio generation for tape save
 - [ ] WAV file loading support
 - [ ] Visual tape deck UI
@@ -112,16 +123,19 @@ This document tracks UX/UI enhancements for Apple1JS, focusing on authentic emul
 ## Technical Architecture Notes
 
 ### Color System
+
 - Design tokens centralize all colors except CRT
 - CRT uses hardcoded #68D391 for authentic phosphor
 - Semantic colors: addresses (blue), values (green), flags (amber)
 
-### Debugger Architecture  
+### Debugger Architecture
+
 - Tabs reduce cognitive load vs all-in-one view
 - 500ms refresh balances responsiveness/performance
 - 768-byte memory view fits typical debug scenarios
 
 ### Performance Considerations
+
 - Web Worker isolation keeps UI responsive
 - Message batching reduces overhead
 - Virtual scrolling for large data sets
@@ -131,6 +145,7 @@ This document tracks UX/UI enhancements for Apple1JS, focusing on authentic emul
 1. **Memory Write**: UI complete but worker lacks implementation
 2. **Component Colors**: Some legacy components still hardcode colors
 3. **Markdown Formatting**: This file has linting warnings
+4. **Tab State Persistence**: ✅ FIXED - Views now maintain their address position when switching tabs
 
 ## Success Metrics
 

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -8,4 +8,8 @@ module.exports = {
     testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$',
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
     setupFiles: ['jest-canvas-mock'],
+    setupFilesAfterEnv: ['<rootDir>/src/test-support/setupTests.ts'],
+    moduleNameMapper: {
+        '^@/(.*)$': '<rootDir>/src/$1',
+    },
 };

--- a/src/components/DebuggerLayout.tsx
+++ b/src/components/DebuggerLayout.tsx
@@ -16,7 +16,8 @@ type DebugView = 'overview' | 'memory' | 'disassembly';
 const DebuggerLayout: React.FC<DebuggerLayoutProps> = ({ worker }) => {
     const [activeView, setActiveView] = useState<DebugView>('overview');
     const [debugInfo, setDebugInfo] = useState<DebugData>({});
-    const [memoryViewAddress] = useState(0x0000);
+    const [memoryViewAddress, setMemoryViewAddress] = useState(0x0000);
+    const [disassemblerAddress, setDisassemblerAddress] = useState(0x0000);
 
     // Listen for debug info updates
     useEffect(() => {
@@ -205,14 +206,19 @@ const DebuggerLayout: React.FC<DebuggerLayoutProps> = ({ worker }) => {
                     <div className="h-full">
                         <MemoryViewerPaginated
                             worker={worker}
-                            startAddress={memoryViewAddress}
+                            currentAddress={memoryViewAddress}
+                            onAddressChange={setMemoryViewAddress}
                         />
                     </div>
                 )}
 
                 {activeView === 'disassembly' && (
                     <div className="h-full">
-                        <DisassemblerPaginated worker={worker} />
+                        <DisassemblerPaginated 
+                            worker={worker}
+                            currentAddress={disassemblerAddress}
+                            onAddressChange={setDisassemblerAddress}
+                        />
                     </div>
                 )}
             </div>

--- a/src/components/__tests__/DebuggerLayout.test.tsx
+++ b/src/components/__tests__/DebuggerLayout.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import DebuggerLayout from '../DebuggerLayout';
+import { IInspectableComponent } from '../../core/@types/IInspectableComponent';
+
+// Mock the child components
+jest.mock('../DisassemblerPaginated', () => ({
+    __esModule: true,
+    default: ({ currentAddress, onAddressChange }: { currentAddress?: number; onAddressChange?: (addr: number) => void }) => (
+        <div data-testid="disassembler">
+            <span data-testid="disassembler-address">{currentAddress}</span>
+            <button onClick={() => onAddressChange?.(0x1234)}>Change Address</button>
+        </div>
+    ),
+}));
+
+jest.mock('../MemoryViewerPaginated', () => ({
+    __esModule: true,
+    default: ({ currentAddress, onAddressChange }: { currentAddress?: number; onAddressChange?: (addr: number) => void }) => (
+        <div data-testid="memory-viewer">
+            <span data-testid="memory-address">{currentAddress}</span>
+            <button onClick={() => onAddressChange?.(0x5678)}>Change Address</button>
+        </div>
+    ),
+}));
+
+jest.mock('../StackViewer', () => ({
+    __esModule: true,
+    default: () => <div data-testid="stack-viewer">Stack Viewer</div>,
+}));
+
+jest.mock('../ExecutionControls', () => ({
+    __esModule: true,
+    default: () => <div data-testid="execution-controls">Execution Controls</div>,
+}));
+
+describe('DebuggerLayout', () => {
+    const mockWorker = {
+        postMessage: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+    } as unknown as Worker;
+
+    const mockRoot = {} as IInspectableComponent;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders overview by default', () => {
+        render(<DebuggerLayout root={mockRoot} worker={mockWorker} />);
+        
+        expect(screen.getByText('Overview')).toBeInTheDocument();
+        expect(screen.getByTestId('execution-controls')).toBeInTheDocument();
+        expect(screen.getByTestId('stack-viewer')).toBeInTheDocument();
+    });
+
+    it('switches between tabs', () => {
+        render(<DebuggerLayout root={mockRoot} worker={mockWorker} />);
+        
+        // Click Memory tab
+        fireEvent.click(screen.getByText('Memory'));
+        expect(screen.getByTestId('memory-viewer')).toBeInTheDocument();
+        expect(screen.queryByTestId('execution-controls')).not.toBeInTheDocument();
+        
+        // Click Disassembly tab
+        fireEvent.click(screen.getByText('Disassembly'));
+        expect(screen.getByTestId('disassembler')).toBeInTheDocument();
+        expect(screen.queryByTestId('memory-viewer')).not.toBeInTheDocument();
+    });
+
+    it('maintains memory viewer address state when switching tabs', () => {
+        render(<DebuggerLayout root={mockRoot} worker={mockWorker} />);
+        
+        // Switch to Memory tab
+        fireEvent.click(screen.getByText('Memory'));
+        
+        // Initial address should be 0
+        expect(screen.getByTestId('memory-address')).toHaveTextContent('0');
+        
+        // Change address
+        fireEvent.click(screen.getByText('Change Address'));
+        expect(screen.getByTestId('memory-address')).toHaveTextContent('22136'); // 0x5678
+        
+        // Switch to Overview and back
+        fireEvent.click(screen.getByText('Overview'));
+        fireEvent.click(screen.getByText('Memory'));
+        
+        // Address should be preserved
+        expect(screen.getByTestId('memory-address')).toHaveTextContent('22136');
+    });
+
+    it('maintains disassembler address state when switching tabs', () => {
+        render(<DebuggerLayout root={mockRoot} worker={mockWorker} />);
+        
+        // Switch to Disassembly tab
+        fireEvent.click(screen.getByText('Disassembly'));
+        
+        // Initial address should be 0
+        expect(screen.getByTestId('disassembler-address')).toHaveTextContent('0');
+        
+        // Change address
+        fireEvent.click(screen.getByText('Change Address'));
+        expect(screen.getByTestId('disassembler-address')).toHaveTextContent('4660'); // 0x1234
+        
+        // Switch to Overview and back
+        fireEvent.click(screen.getByText('Overview'));
+        fireEvent.click(screen.getByText('Disassembly'));
+        
+        // Address should be preserved
+        expect(screen.getByTestId('disassembler-address')).toHaveTextContent('4660');
+    });
+
+    it('maintains separate address states for memory and disassembler', () => {
+        render(<DebuggerLayout root={mockRoot} worker={mockWorker} />);
+        
+        // Set memory address
+        fireEvent.click(screen.getByText('Memory'));
+        fireEvent.click(screen.getByText('Change Address'));
+        
+        // Set disassembler address
+        fireEvent.click(screen.getByText('Disassembly'));
+        fireEvent.click(screen.getByText('Change Address'));
+        
+        // Check both maintain their own state
+        fireEvent.click(screen.getByText('Memory'));
+        expect(screen.getByTestId('memory-address')).toHaveTextContent('22136'); // 0x5678
+        
+        fireEvent.click(screen.getByText('Disassembly'));
+        expect(screen.getByTestId('disassembler-address')).toHaveTextContent('4660'); // 0x1234
+    });
+});

--- a/src/components/__tests__/MemoryViewerPaginated.test.tsx
+++ b/src/components/__tests__/MemoryViewerPaginated.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import MemoryViewerPaginated from '../MemoryViewerPaginated';
 import { WORKER_MESSAGES } from '../../apple1/TSTypes';
 
@@ -24,12 +24,14 @@ describe('MemoryViewerPaginated', () => {
 
     const simulateMemoryData = (start: number, length: number) => {
         const data = new Array(length).fill(0).map((_, i) => (start + i) % 256);
-        messageHandler(new MessageEvent('message', {
-            data: {
-                type: WORKER_MESSAGES.MEMORY_RANGE_DATA,
-                data: { start, data }
-            }
-        }));
+        act(() => {
+            messageHandler(new MessageEvent('message', {
+                data: {
+                    type: WORKER_MESSAGES.MEMORY_RANGE_DATA,
+                    data: { start, data }
+                }
+            }));
+        });
     };
 
     it('renders with initial address', () => {

--- a/src/components/__tests__/MemoryViewerPaginated.test.tsx
+++ b/src/components/__tests__/MemoryViewerPaginated.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import MemoryViewerPaginated from '../MemoryViewerPaginated';
+import { WORKER_MESSAGES } from '../../apple1/TSTypes';
+
+describe('MemoryViewerPaginated', () => {
+    const mockWorker = {
+        postMessage: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+    } as unknown as Worker;
+
+    let messageHandler: (event: MessageEvent) => void;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        
+        // Capture the message handler
+        mockWorker.addEventListener = jest.fn((event: string, handler: EventListenerOrEventListenerObject) => {
+            if (event === 'message' && typeof handler === 'function') {
+                messageHandler = handler as (event: MessageEvent) => void;
+            }
+        });
+    });
+
+    const simulateMemoryData = (start: number, length: number) => {
+        const data = new Array(length).fill(0).map((_, i) => (start + i) % 256);
+        messageHandler(new MessageEvent('message', {
+            data: {
+                type: WORKER_MESSAGES.MEMORY_RANGE_DATA,
+                data: { start, data }
+            }
+        }));
+    };
+
+    it('renders with initial address', () => {
+        render(<MemoryViewerPaginated worker={mockWorker} startAddress={0x1000} />);
+        
+        const addressInput = screen.getByPlaceholderText('0000') as HTMLInputElement;
+        expect(addressInput.value).toBe('1000');
+    });
+
+    it('uses external address when provided', () => {
+        render(<MemoryViewerPaginated 
+            worker={mockWorker} 
+            startAddress={0x1000}
+            currentAddress={0x2000}
+        />);
+        
+        const addressInput = screen.getByPlaceholderText('0000') as HTMLInputElement;
+        expect(addressInput.value).toBe('2000');
+    });
+
+    it('calls onAddressChange when address changes', async () => {
+        const onAddressChange = jest.fn();
+        render(<MemoryViewerPaginated 
+            worker={mockWorker} 
+            onAddressChange={onAddressChange}
+        />);
+        
+        const addressInput = screen.getByPlaceholderText('0000') as HTMLInputElement;
+        
+        // Change address via input
+        fireEvent.change(addressInput, { target: { value: '5678' } });
+        fireEvent.keyDown(addressInput, { key: 'Enter' });
+        
+        await waitFor(() => {
+            expect(onAddressChange).toHaveBeenCalledWith(0x5678);
+        });
+    });
+
+    it('navigates with arrow buttons', async () => {
+        const onAddressChange = jest.fn();
+        render(<MemoryViewerPaginated 
+            worker={mockWorker} 
+            currentAddress={0x1000}
+            onAddressChange={onAddressChange}
+        />);
+        
+        // Simulate memory data
+        simulateMemoryData(0x1000, 256);
+        
+        // Click down arrow
+        const downButton = screen.getByTitle('Next page (↓)');
+        fireEvent.click(downButton);
+        
+        await waitFor(() => {
+            // Should advance by the visible size
+            expect(onAddressChange).toHaveBeenCalled();
+            const lastCall = onAddressChange.mock.calls[onAddressChange.mock.calls.length - 1];
+            expect(lastCall[0]).toBeGreaterThan(0x1000);
+        });
+    });
+
+    it('does not cause flickering with external address changes', () => {
+        const onAddressChange = jest.fn();
+        const { rerender } = render(<MemoryViewerPaginated 
+            worker={mockWorker} 
+            currentAddress={0x1000}
+            onAddressChange={onAddressChange}
+        />);
+        
+        // Clear initial calls
+        onAddressChange.mockClear();
+        
+        // Re-render with same address - should not trigger onChange
+        rerender(<MemoryViewerPaginated 
+            worker={mockWorker} 
+            currentAddress={0x1000}
+            onAddressChange={onAddressChange}
+        />);
+        
+        expect(onAddressChange).not.toHaveBeenCalled();
+    });
+
+    it('displays memory data correctly', () => {
+        render(<MemoryViewerPaginated worker={mockWorker} />);
+        
+        // Simulate memory data
+        simulateMemoryData(0x0000, 256);
+        
+        // Check that hex values are displayed (00 appears multiple times, use getAllByText)
+        const hexValues = screen.getAllByText('00');
+        expect(hexValues.length).toBeGreaterThan(0);
+        
+        // Check that ASCII column exists
+        expect(screen.getByText('ASCII')).toBeInTheDocument();
+    });
+
+    it('handles address input validation', () => {
+        render(<MemoryViewerPaginated worker={mockWorker} />);
+        
+        const addressInput = screen.getByPlaceholderText('0000') as HTMLInputElement;
+        
+        // Try to enter invalid characters
+        fireEvent.change(addressInput, { target: { value: 'GGGG' } });
+        expect(addressInput.value).toBe(''); // Should reject non-hex characters
+        
+        // Enter valid hex
+        fireEvent.change(addressInput, { target: { value: 'ABCD' } });
+        expect(addressInput.value).toBe('ABCD');
+    });
+
+    it('limits address input to 4 characters', () => {
+        render(<MemoryViewerPaginated worker={mockWorker} />);
+        
+        const addressInput = screen.getByPlaceholderText('0000') as HTMLInputElement;
+        
+        // Set 4 characters - should work
+        fireEvent.change(addressInput, { target: { value: '1234' } });
+        expect(addressInput.value).toBe('1234');
+        
+        // Try to set more than 4 characters - should keep previous value
+        fireEvent.change(addressInput, { target: { value: '12345' } });
+        expect(addressInput.value).toBe('1234'); // Component ignores inputs > 4 chars
+    });
+});

--- a/src/test-support/setupTests.ts
+++ b/src/test-support/setupTests.ts
@@ -1,0 +1,27 @@
+/* eslint-disable no-undef */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import '@testing-library/jest-dom';
+
+// Mock ResizeObserver
+(global as any).ResizeObserver = jest.fn().mockImplementation(() => ({
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+    disconnect: jest.fn(),
+}));
+
+// Mock requestAnimationFrame
+(global as any).requestAnimationFrame = jest.fn((callback: FrameRequestCallback) => {
+    setTimeout(callback, 0);
+    return 0;
+});
+
+// Mock window.addEventListener for resize events
+const resizeListeners: Array<() => void> = [];
+const originalAddEventListener = window.addEventListener.bind(window);
+window.addEventListener = jest.fn((event: any, listener: any) => {
+    if (event === 'resize' && typeof listener === 'function') {
+        resizeListeners.push(listener);
+    } else {
+        originalAddEventListener(event, listener);
+    }
+}) as any;


### PR DESCRIPTION
## Summary

- Fixed debugger Memory and Disassembler views losing their address position when switching tabs
- Eliminated flickering effect during address navigation
- Resolved window resize causing unwanted state resets

## Problem

Users reported that switching between debugger tabs would reset views back to address `0x0000`, making debugging workflows inefficient. Additionally, there was a flickering effect when changing addresses due to circular state synchronization.

## Solution

1. **Lifted state to parent**: Moved address state from individual components to `DebuggerLayout`
2. **One-way data flow**: Child components notify parent of changes without creating feedback loops
3. **Eliminated circular sync**: Removed bidirectional synchronization that caused flickering
4. **Persistent navigation**: Views now maintain their position across tab switches and window resizes

## Technical Changes

- **DebuggerLayout.tsx**: Added `memoryViewAddress` and `disassemblerAddress` state
- **DisassemblerPaginated.tsx**: Accept `currentAddress` and `onAddressChange` props
- **MemoryViewerPaginated.tsx**: Accept `currentAddress` and `onAddressChange` props
- **user_experience_analysis.md**: Updated to reflect fix completion

## Test Plan

- [x] Switch between Memory and Disassembly tabs - position should persist
- [x] Navigate to different addresses (e.g., 0x0280) and switch tabs - should maintain position
- [x] Resize window while in disassembler - should not reset address
- [x] Use address input field - should not flicker between old and new values
- [x] Run `yarn run lint && yarn run type-check` - all pass

🤖 Generated with [Claude Code](https://claude.ai/code)