### PR TITLE
feat: Enhanced debugger with auto-follow PC, register view, and deterministic breakpoints

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,9 +1,8 @@
-
 {
-  semi: true,
-  trailingComma: "all",
-  singleQuote: true,
-  printWidth: 120,
-  tabWidth: 4,
-  endOfLine: "auto"
-  }
+    "semi": true,
+    "trailingComma": "all",
+    "singleQuote": true,
+    "printWidth": 120,
+    "tabWidth": 4,
+    "endOfLine": "auto"
+}

--- a/docs/user_experience_analysis.md
+++ b/docs/user_experience_analysis.md
@@ -56,6 +56,7 @@ This document tracks UX/UI enhancements for Apple1JS, focusing on authentic emul
 
 - [x] Step-by-step execution (CPU already supports it) ✅
 - [x] Breakpoint UI with visual indicators ✅
+- [x] Auto-follow PC during step execution ✅
 - [ ] Run-to-cursor in disassembler
 - [ ] Conditional breakpoints (e.g., "break when A=$FF")
 
@@ -64,6 +65,7 @@ This document tracks UX/UI enhancements for Apple1JS, focusing on authentic emul
 - Worker messages exist: STEP, SET_BREAKPOINT
 - Need UI integration in DebuggerLayout
 - Store breakpoints in worker for performance
+- Auto-follow PC: Implemented to track PC during stepping, automatically navigates view when PC jumps outside visible range
 
 ### Memory Analysis
 

--- a/src/components/CompactCpuRegisters.tsx
+++ b/src/components/CompactCpuRegisters.tsx
@@ -1,0 +1,144 @@
+import React, { memo } from 'react';
+import { DebugData } from '../apple1/TSTypes';
+
+interface CompactCpuRegistersProps {
+    debugInfo: DebugData;
+}
+
+// Helper to format register values consistently
+const formatHex = (value: string | number | undefined, digits: number): string => {
+    if (value === undefined || value === null) {
+        return digits === 4 ? '$0000' : '$00';
+    }
+    if (typeof value === 'string' && value.startsWith('$')) {
+        // Already formatted, ensure correct padding
+        const hex = value.substring(1);
+        return '$' + hex.padStart(digits, '0').toUpperCase();
+    }
+    // For numeric values or plain strings, parse as number
+    const num = typeof value === 'string' ? parseInt(value, 10) : value;
+    return '$' + num.toString(16).padStart(digits, '0').toUpperCase();
+};
+
+const CompactCpuRegistersComponent: React.FC<CompactCpuRegistersProps> = ({ debugInfo }) => {
+    const cpu = debugInfo.cpu || {};
+    
+    // Extract register values with defaults
+    const registers = {
+        pc: formatHex(cpu.REG_PC || cpu.PC, 4),
+        a: formatHex(cpu.REG_A || cpu.A, 2),
+        x: formatHex(cpu.REG_X || cpu.X, 2),
+        y: formatHex(cpu.REG_Y || cpu.Y, 2),
+        sp: formatHex(cpu.REG_S || cpu.S, 2),
+    };
+    
+    // Extract flag values
+    const flags = {
+        n: cpu.FLAG_N === 'SET' || cpu.N === 'SET',
+        v: cpu.FLAG_V === 'SET' || cpu.V === 'SET',
+        d: cpu.FLAG_D === 'SET' || cpu.D === 'SET',
+        i: cpu.FLAG_I === 'SET' || cpu.I === 'SET',
+        z: cpu.FLAG_Z === 'SET' || cpu.Z === 'SET',
+        c: cpu.FLAG_C === 'SET' || cpu.C === 'SET',
+    };
+    
+    return (
+        <div className="bg-surface-secondary/50 border-t border-border-subtle px-md py-xs">
+            <div className="flex items-center justify-between text-xs">
+                {/* Registers */}
+                <div className="flex items-center gap-md">
+                    <div className="flex items-center gap-xs">
+                        <span className="text-text-secondary font-medium">PC:</span>
+                        <span className="font-mono text-data-address">{registers.pc}</span>
+                    </div>
+                    <div className="flex items-center gap-xs">
+                        <span className="text-text-secondary font-medium">A:</span>
+                        <span className="font-mono text-data-value">{registers.a}</span>
+                    </div>
+                    <div className="flex items-center gap-xs">
+                        <span className="text-text-secondary font-medium">X:</span>
+                        <span className="font-mono text-data-value">{registers.x}</span>
+                    </div>
+                    <div className="flex items-center gap-xs">
+                        <span className="text-text-secondary font-medium">Y:</span>
+                        <span className="font-mono text-data-value">{registers.y}</span>
+                    </div>
+                    <div className="flex items-center gap-xs">
+                        <span className="text-text-secondary font-medium">SP:</span>
+                        <span className="font-mono text-data-value">{registers.sp}</span>
+                    </div>
+                </div>
+                
+                {/* Flags */}
+                <div className="flex items-center gap-xs">
+                    <span className="text-text-secondary font-medium mr-xs">Flags:</span>
+                    <div className="font-mono flex gap-[2px]">
+                        <span className={flags.n ? 'text-success' : 'text-text-disabled'}>N</span>
+                        <span className={flags.v ? 'text-success' : 'text-text-disabled'}>V</span>
+                        <span className="text-text-disabled">-</span>
+                        <span className="text-text-disabled">B</span>
+                        <span className={flags.d ? 'text-success' : 'text-text-disabled'}>D</span>
+                        <span className={flags.i ? 'text-success' : 'text-text-disabled'}>I</span>
+                        <span className={flags.z ? 'text-success' : 'text-text-disabled'}>Z</span>
+                        <span className={flags.c ? 'text-success' : 'text-text-disabled'}>C</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+// Custom comparison function to check if register values actually changed
+const areRegistersEqual = (prevProps: CompactCpuRegistersProps, nextProps: CompactCpuRegistersProps): boolean => {
+    const prevCpu = prevProps.debugInfo.cpu || {};
+    const nextCpu = nextProps.debugInfo.cpu || {};
+    
+    // Compare register values with consistent formatting
+    const prevRegs = {
+        pc: formatHex(prevCpu.REG_PC || prevCpu.PC, 4),
+        a: formatHex(prevCpu.REG_A || prevCpu.A, 2),
+        x: formatHex(prevCpu.REG_X || prevCpu.X, 2),
+        y: formatHex(prevCpu.REG_Y || prevCpu.Y, 2),
+        sp: formatHex(prevCpu.REG_S || prevCpu.S, 2),
+        flagN: prevCpu.FLAG_N === 'SET' || prevCpu.N === 'SET',
+        flagV: prevCpu.FLAG_V === 'SET' || prevCpu.V === 'SET',
+        flagD: prevCpu.FLAG_D === 'SET' || prevCpu.D === 'SET',
+        flagI: prevCpu.FLAG_I === 'SET' || prevCpu.I === 'SET',
+        flagZ: prevCpu.FLAG_Z === 'SET' || prevCpu.Z === 'SET',
+        flagC: prevCpu.FLAG_C === 'SET' || prevCpu.C === 'SET',
+    };
+    
+    const nextRegs = {
+        pc: formatHex(nextCpu.REG_PC || nextCpu.PC, 4),
+        a: formatHex(nextCpu.REG_A || nextCpu.A, 2),
+        x: formatHex(nextCpu.REG_X || nextCpu.X, 2),
+        y: formatHex(nextCpu.REG_Y || nextCpu.Y, 2),
+        sp: formatHex(nextCpu.REG_S || nextCpu.S, 2),
+        flagN: nextCpu.FLAG_N === 'SET' || nextCpu.N === 'SET',
+        flagV: nextCpu.FLAG_V === 'SET' || nextCpu.V === 'SET',
+        flagD: nextCpu.FLAG_D === 'SET' || nextCpu.D === 'SET',
+        flagI: nextCpu.FLAG_I === 'SET' || nextCpu.I === 'SET',
+        flagZ: nextCpu.FLAG_Z === 'SET' || nextCpu.Z === 'SET',
+        flagC: nextCpu.FLAG_C === 'SET' || nextCpu.C === 'SET',
+    };
+    
+    // Return true if all values are equal (prevents re-render)
+    return (
+        prevRegs.pc === nextRegs.pc &&
+        prevRegs.a === nextRegs.a &&
+        prevRegs.x === nextRegs.x &&
+        prevRegs.y === nextRegs.y &&
+        prevRegs.sp === nextRegs.sp &&
+        prevRegs.flagN === nextRegs.flagN &&
+        prevRegs.flagV === nextRegs.flagV &&
+        prevRegs.flagD === nextRegs.flagD &&
+        prevRegs.flagI === nextRegs.flagI &&
+        prevRegs.flagZ === nextRegs.flagZ &&
+        prevRegs.flagC === nextRegs.flagC
+    );
+};
+
+// Memoized component that only re-renders when register values actually change
+const CompactCpuRegisters = memo(CompactCpuRegistersComponent, areRegistersEqual);
+
+export default CompactCpuRegisters;

--- a/src/components/DisassemblerPaginated.tsx
+++ b/src/components/DisassemblerPaginated.tsx
@@ -194,6 +194,7 @@ const DisassemblerPaginated: React.FC<DisassemblerProps> = ({ worker, currentAdd
             
             if (event.data?.type === WORKER_MESSAGES.BREAKPOINT_HIT) {
                 const hitPC = event.data.data as number;
+                setCurrentPC(hitPC); // Update currentPC for highlighting
                 navigateTo(hitPC);
             }
             
@@ -202,6 +203,15 @@ const DisassemblerPaginated: React.FC<DisassemblerProps> = ({ worker, currentAdd
                 // It's requested only when paused for the register display
                 const debugData = event.data.data as DebugData;
                 setDebugInfo(debugData);
+                
+                // Also update PC from DEBUG_INFO
+                const pcValue = debugData.cpu?.REG_PC || debugData.cpu?.PC;
+                if (pcValue !== undefined) {
+                    const pc = typeof pcValue === 'string' 
+                        ? parseInt(pcValue.replace('$', ''), 16)
+                        : pcValue;
+                    setCurrentPC(pc);
+                }
             }
         };
 

--- a/src/core/CPU6502.ts
+++ b/src/core/CPU6502.ts
@@ -1434,7 +1434,12 @@ class CPU6502 implements IClockable, IInspectableComponent {
     performBulkSteps(steps: number): void {
         let currentCycleCount = 0;
         while (currentCycleCount <= steps) {
-            currentCycleCount += this.performSingleStep();
+            const cyclesExecuted = this.performSingleStep();
+            // If no cycles were executed (execution hook returned false), stop
+            if (cyclesExecuted === 0) {
+                break;
+            }
+            currentCycleCount += cyclesExecuted;
         }
     }
 


### PR DESCRIPTION
## Summary

This PR significantly enhances the Apple1JS debugger with three major improvements:

1. **Auto-follow PC during stepping** - The disassembler view automatically follows the program counter when stepping through code, eliminating manual navigation
2. **Compact CPU register view** - Displays essential registers (PC, A, X, Y, SP, flags) when execution is paused
3. **Deterministic breakpoint system** - Replaces flawed polling with execution hooks for reliable breakpoint detection

## Key Changes

### Auto-follow PC
- Tracks when user is stepping through code
- Automatically navigates view when PC jumps outside visible range
- Handles jumps, branches, and subroutine calls seamlessly

### Register Display
- Minimal height (~30px) register bar below toolbar
- Only shown when paused/debugging
- Consistent hex formatting with memoization to prevent flicker
- Updates only when registers actually change

### Breakpoint System Overhaul
- Added execution hook to CPU6502 class
- Hook checks PC before each instruction fetch
- Fixed race condition where fast instructions could skip breakpoints
- Fixed `performBulkSteps` to halt immediately on breakpoint hit
- Proper PC highlighting when stopped at breakpoint

## Technical Details

- Zero performance overhead when not debugging (hooks removed when no breakpoints)
- Synchronous, deterministic behavior matching hardware debuggers
- Clean separation of concerns - CPU doesn't know about breakpoints
- All existing tests pass

## Testing

- Breakpoints now work reliably at any address (RAM or ROM)
- Stepping works correctly when sitting on a breakpoint
- PC highlighting properly shows current instruction
- Register display updates correctly during stepping

🤖 Generated with [Claude Code](https://claude.ai/code)