### PR TITLE
fix: maintain pause state when switching debugger tabs

### DIFF
--- a/src/apple1/@types/WorkerMessages.ts
+++ b/src/apple1/@types/WorkerMessages.ts
@@ -28,7 +28,8 @@ export type WorkerMessage =
     | BaseWorkerMessage<WORKER_MESSAGES.CLEAR_BREAKPOINT, number>
     | BaseWorkerMessage<WORKER_MESSAGES.CLEAR_ALL_BREAKPOINTS>
     | BaseWorkerMessage<WORKER_MESSAGES.GET_BREAKPOINTS>
-    | BaseWorkerMessage<WORKER_MESSAGES.SET_DEBUGGER_ACTIVE, boolean>;
+    | BaseWorkerMessage<WORKER_MESSAGES.SET_DEBUGGER_ACTIVE, boolean>
+    | BaseWorkerMessage<WORKER_MESSAGES.GET_EMULATION_STATUS>;
 
 /**
  * Type guard to check if a message is a valid WorkerMessage

--- a/src/apple1/Apple.worker.ts
+++ b/src/apple1/Apple.worker.ts
@@ -249,6 +249,14 @@ onmessage = function (e: MessageEvent<WorkerMessage>) {
             }
             break;
         }
+        case WORKER_MESSAGES.GET_EMULATION_STATUS: {
+            // Respond with current emulation status
+            postMessage({ 
+                data: isPaused ? 'paused' : 'running', 
+                type: WORKER_MESSAGES.EMULATION_STATUS 
+            });
+            break;
+        }
     }
 };
 

--- a/src/apple1/TSTypes.ts
+++ b/src/apple1/TSTypes.ts
@@ -39,6 +39,7 @@ export enum WORKER_MESSAGES {
     BREAKPOINTS_DATA, // Response with current breakpoints
     BREAKPOINT_HIT, // Notification when breakpoint is hit
     SET_DEBUGGER_ACTIVE, // Set debugger visibility state
+    GET_EMULATION_STATUS, // Request current emulation status
 }
 
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -100,6 +100,23 @@ const App = ({ worker, apple1Instance }: Props): JSX.Element => {
         };
     }, [worker, addMessage]);
 
+    // Listen for emulation status updates
+    useEffect(() => {
+        const handleMessage = (e: MessageEvent) => {
+            if (e.data.type === WORKER_MESSAGES.EMULATION_STATUS) {
+                const status = e.data.data;
+                setIsPaused(status === 'paused');
+            }
+        };
+
+        worker.addEventListener('message', handleMessage);
+        
+        // Query current status on mount
+        worker.postMessage({ type: WORKER_MESSAGES.GET_EMULATION_STATUS });
+        
+        return () => worker.removeEventListener('message', handleMessage);
+    }, [worker]);
+
     // --- State Save/Load Handlers ---
     const handleSaveState = useCallback(
         (e: React.MouseEvent<HTMLAnchorElement>) => {
@@ -156,7 +173,7 @@ const App = ({ worker, apple1Instance }: Props): JSX.Element => {
             } else {
                 worker.postMessage({ type: WORKER_MESSAGES.PAUSE_EMULATION });
             }
-            setIsPaused((prev) => !prev);
+            // Don't toggle state here - it will be updated by EMULATION_STATUS message
         },
         [worker, isPaused],
     );

--- a/src/components/CompactExecutionControls.tsx
+++ b/src/components/CompactExecutionControls.tsx
@@ -60,6 +60,10 @@ const CompactExecutionControls: React.FC<CompactExecutionControlsProps> = ({
         };
 
         worker.addEventListener('message', handleMessage);
+        
+        // Query current status on mount
+        worker.postMessage({ type: WORKER_MESSAGES.GET_EMULATION_STATUS });
+        
         return () => worker.removeEventListener('message', handleMessage);
     }, [worker]);
 

--- a/src/components/DisassemblerPaginated.tsx
+++ b/src/components/DisassemblerPaginated.tsx
@@ -295,6 +295,10 @@ const DisassemblerPaginated: React.FC<DisassemblerProps> = ({ worker, currentAdd
         };
 
         worker.addEventListener('message', handleMessage);
+        
+        // Query current status on mount
+        worker.postMessage({ type: WORKER_MESSAGES.GET_EMULATION_STATUS });
+        
         return () => worker.removeEventListener('message', handleMessage);
     }, [worker]);
     

--- a/src/components/ExecutionControls.tsx
+++ b/src/components/ExecutionControls.tsx
@@ -48,6 +48,10 @@ const ExecutionControls: React.FC<ExecutionControlsProps> = ({ worker }) => {
         };
 
         worker.addEventListener('message', handleMessage);
+        
+        // Query current status on mount
+        worker.postMessage({ type: WORKER_MESSAGES.GET_EMULATION_STATUS });
+        
         return () => worker.removeEventListener('message', handleMessage);
     }, [worker]);
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '4.12.3';
+export const APP_VERSION = '4.12.4';


### PR DESCRIPTION
## Summary
- Fixed issue where pause state was lost when switching between debugger tabs
- Components now query the worker for current emulation status on mount to stay synchronized
- Prevents desynchronization between worker and UI pause states

## Test plan
- [x] Pause emulator in Overview tab
- [x] Switch to Memory tab - pause state is maintained
- [x] Switch to Disassembly tab - pause state is maintained
- [x] Switch back to Overview tab - pause state is maintained
- [x] Resume emulator and verify state persists across tab switches
- [x] Test pause/resume from different tabs - all stay synchronized
- [x] All tests pass and CI pipeline is green

🤖 Generated with [Claude Code](https://claude.ai/code)