### PR TITLE
docs: update documentation language for personal project context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,23 +18,31 @@
 
 Apple1JS is a browser-based Apple 1 computer emulator built with TypeScript/React. Features cycle-accurate 6502 CPU emulation, authentic CRT display with phosphor effects, and full debugging capabilities. The architecture separates emulation logic (Web Worker) from UI for performance.
 
+**This is a personal hobby project** - I use it to learn about new technologies and patterns, including exploring AI for coding and feature development. There are no deadlines, sprints, or engineering timelines. If an idea seems interesting, we can explore it at our own pace. I enjoy gap analysis and setting goals, but everything remains driven by passion and learning rather than external pressure.
+
 ## 🧠 Claude Instructions
 
-**Phase 1 – Analysis & Proposal**
+**Working Style**
 
-- Document findings in `@docs/architecture_analysis.md` or `@docs/user_experience_analysis.md`
-- **CRITICAL**: Wait for "✅ Phase 1 Approved" - prevents wasted work and ensures alignment
+- Keep documentation informal and focused on learning/exploration
+- Avoid corporate language (sprints, deadlines, action items, etc.)
+- Frame improvements as "ideas to explore" or "things that would be cool"
+- Remember this is a passion project for learning, not a production system
 
-**Phase 2 – Implementation**
+**When Analyzing/Proposing Changes**
 
-- Follow approved plan exactly - deviations require discussion
+- Document findings in `@docs/` folder as informal explorations
+- Feel free to suggest improvements, but frame them as opportunities to learn
+- No rigid phases - we can analyze and implement as we go
+
+**When Implementing**
+
 - Run tests before/after changes to ensure no regression
 - **MANDATORY**: Update `src/version.ts` BEFORE creating any pull request
   - Minor version bump for new features (e.g., 4.11.0 → 4.12.0)
   - Patch version bump for bug fixes (e.g., 4.11.0 → 4.11.1)
   - Major version bump for breaking changes (e.g., 4.11.0 → 5.0.0)
-- Run full CI pipeline: `yarn run lint && yarn run type-check && yarn run test:ci`
-- Mark completed items with ✅ in analysis docs for tracking
+- Run quality checks: `yarn run lint && yarn run type-check && yarn run test:ci`
 
 **CRITICAL**: Never create a pull request without updating the version number first!
 

--- a/docs/architecture_analysis.md
+++ b/docs/architecture_analysis.md
@@ -1,8 +1,8 @@
 # Apple1JS Architecture Analysis
 
-## Overview
+## What's This?
 
-This document captures the architectural analysis of the Apple1JS project, identifying opportunities for improvement in code organization, consistency, and maintainability.
+These are my notes from looking at the Apple1JS architecture - places where I could improve code organization and make things more consistent.
 
 ## UI Layout & Design System Analysis
 
@@ -312,9 +312,9 @@ if (address >= STACK_START && address <= STACK_END) { ... }
 - Document expected properties
 - Add TypeScript interface enforcement
 
-## UI Layout Implementation Plan
+## UI Layout Improvements
 
-### Phase 1 - Design System Foundation
+### Design System Foundation
 
 - [x] Create design tokens file (`src/styles/tokens.ts`)
 - [x] Implement typography scale in Tailwind config
@@ -322,7 +322,7 @@ if (address >= STACK_START && address <= STACK_END) { ... }
 - [x] Create spacing system constants
 - [x] Add utility CSS classes for common patterns
 
-### Phase 2 - Component Refactoring
+### Component Improvements
 
 - [x] Refactor InspectorView with improved layout
 - [x] Create reusable MetricCard component
@@ -330,7 +330,7 @@ if (address >= STACK_START && address <= STACK_END) { ... }
 - [x] Add section containers with proper spacing
 - [x] Enhance visual hierarchy with borders/backgrounds
 
-### Phase 3 - Data Display Enhancement
+### Better Data Display
 
 - [x] Implement color coding for data types
 - [x] Add status indicators with appropriate colors
@@ -338,7 +338,7 @@ if (address >= STACK_START && address <= STACK_END) { ... }
 - [x] Improve alignment and spacing in data grids
 - [x] Add hover states and transitions
 
-### Phase 4 - Responsive & Accessibility
+### Responsive & Accessibility
 
 - [x] Ensure mobile-friendly layout
 - [x] Add focus indicators
@@ -346,25 +346,25 @@ if (address >= STACK_START && address <= STACK_END) { ... }
 - [x] Test with screen readers
 - [x] Optimize for different screen sizes
 
-## Legacy Implementation Priority & Status
+## Things I've Done
 
-### Phase 1 - Quick Wins
+### Easy Stuff I Fixed
 
-- [x] Standardize naming conventions
-- [x] Extract magic numbers
-- [x] Replace console.log usage
+- [x] Made naming more consistent
+- [x] Got rid of magic numbers
+- [x] Replaced console.log with proper logging
 
-### Phase 2 - Type Safety
+### Type Safety Improvements
 
-- [x] Define proper types for all `unknown` usage
-- [x] Consolidate type definitions
-- [x] Add strict type checking
+- [x] Fixed all the `unknown` types
+- [x] Put type definitions in one place
+- [x] Added stricter type checking
 
-### Phase 3 - Pattern Consistency
+### Made Patterns More Consistent
 
-- [x] Standardize IInspectableComponent
-- [x] Implement consistent error handling
-- [x] Document architectural decisions
+- [x] Standardized the IInspectableComponent interface
+- [x] Made error handling work the same way everywhere
+- [x] Documented why I made certain decisions
 
 ## Completed Work
 
@@ -385,6 +385,6 @@ if (address >= STACK_START && address <= STACK_END) { ... }
 - **Developer Experience**: Clear conventions and patterns
 - **Code Quality**: Better alignment with TypeScript best practices
 
-## Conclusion
+## Summary
 
-The Apple1JS project has a solid architectural foundation with good separation of concerns and modular design. The recommended improvements focus on consistency and type safety rather than major architectural changes. These enhancements will make the codebase more maintainable and easier to extend while preserving the existing functionality.
+The Apple1JS architecture is pretty solid - good separation of concerns and nice modular design. Most of what I fixed was making things more consistent and type-safe rather than big architectural changes. This should make it easier to work with and add new features.

--- a/docs/cpu_timing_validation_report.md
+++ b/docs/cpu_timing_validation_report.md
@@ -1,10 +1,10 @@
 # CPU6502 Timing Validation Report
 
-## Executive Summary
+## What This Is
 
-This report validates the Apple1JS CPU6502 implementation timing accuracy against standard 6502 microprocessor reference specifications. The analysis focuses on critical instruction types: ADC, LDA, STA, BRK, JSR, RTS, branches, and read-modify-write operations.
+I wanted to check if my CPU6502 timing implementation matches the real 6502 specs. This covers the main instruction types: ADC, LDA, STA, BRK, JSR, RTS, branches, and read-modify-write operations.
 
-**Overall Assessment:** ✅ **Highly Accurate** - The implementation demonstrates excellent timing accuracy with only minor discrepancies in specific edge cases.
+**How'd it go?** ✅ **Pretty darn accurate!** - The timing is spot-on with just a few edge cases to think about.
 
 ## Current Implementation Timing Analysis
 
@@ -278,42 +278,40 @@ The implementation prioritizes accuracy over micro-optimizations, which is appro
 
 ## Recommendations
 
-### High Priority (None - Implementation is Accurate)
+### Things That Work Great
 
-No critical timing issues found that require immediate attention.
+No timing bugs found! Everything matches the specs.
 
-### Medium Priority (Code Quality)
+### Code Cleanup Ideas (if I feel like it)
 
-1. **Standardize cycle counting patterns** - Move all cycle additions to a consistent location (addressing mode vs. instruction method)
-2. **Add timing validation tests** - Create unit tests that verify cycle counts for key instruction sequences
-3. **Document timing assumptions** - Add comments explaining timing decisions for complex cases
+1. **Make cycle counting more consistent** - Right now cycle additions happen in different places
+2. **Add some timing tests** - Would be nice to have tests that verify the cycle counts
+3. **Add more comments** - Explain why certain timing decisions were made
 
-### Low Priority (Enhancement)
+### Cool Features to Maybe Add Someday
 
-1. **Cycle-accurate mode** - Consider adding a mode that tracks sub-cycle timing for debugging
-2. **Performance profiling** - Add optional cycle counting statistics for performance analysis
+1. **Sub-cycle accuracy** - Could track timing at an even finer level for hardcore debugging
+2. **Performance stats** - Show cycle count statistics while running
 
-## Conclusion
+## Summary
 
-The Apple1JS CPU6502 timing implementation demonstrates **excellent accuracy** when compared to standard 6502 reference specifications. All critical instructions (ADC, LDA, STA, JSR, RTS, BRK, branches, and RMW operations) implement correct cycle timing including proper handling of page boundary crossings.
+The timing is really accurate! All the important instructions (ADC, LDA, STA, JSR, RTS, BRK, branches, and RMW operations) have the right cycle counts, including the tricky page boundary crossing cases.
 
-**Key Strengths:**
+**What works well:**
 
-- ✅ All instruction timings match reference specifications
-- ✅ Proper page boundary crossing detection and handling
-- ✅ Correct differentiation between load/store timing behavior
-- ✅ Accurate interrupt and subroutine timing
-- ✅ Proper read-modify-write cycle modeling
+- ✅ All timings match the official specs
+- ✅ Page boundary crossings work correctly
+- ✅ Load vs store timing differences are right
+- ✅ Interrupts and subroutines take the right number of cycles
+- ✅ Read-modify-write operations are accurate
 
-**Minor Areas for Improvement:**
+**Things that could be tidier:**
 
-- Code organization and consistency (no timing accuracy impact)
-- Additional test coverage for timing validation
-- Documentation of timing design decisions
+- The code could be more organized (but timing is still correct)
+- Could use more tests
+- Could use more comments
 
-**Overall Rating:** ⭐⭐⭐⭐⭐ **Highly Accurate Implementation**
-
-The implementation is suitable for accurate Apple 1 emulation and maintains compatibility with original 6502 timing behavior.
+**Bottom line:** The timing is accurate enough for authentic Apple 1 emulation!
 
 ---
 

--- a/docs/performance_analysis.md
+++ b/docs/performance_analysis.md
@@ -1,8 +1,8 @@
 # Performance Analysis: Disassembler & Debug Components
 
-## Overview
+## What's This About
 
-Analysis of performance issues in the disassembler and debug components, particularly CPU overhead when the disassembler tab is open.
+I noticed the CPU usage goes up when the debugger is open, especially with the disassembler tab. Here's what I found when digging into it.
 
 ## Key Findings
 
@@ -56,9 +56,9 @@ Components poll for memory data even when:
 - With multiple tabs: Can reach 5-10% CPU usage
 - During stepping/debugging: Additional spikes
 
-## Recommended Optimizations
+## Ideas to Make It Faster
 
-### 1. Conditional Updates (High Priority)
+### 1. Only Update When Needed
 
 Only send debug data when needed:
 
@@ -73,57 +73,57 @@ if (debuggerActive) {
 }
 ```
 
-### 2. Consolidate Update Mechanisms (High Priority)
+### 2. Combine the Update Messages
 
 - Remove the global 100ms `DEBUG_DATA` timer
 - Use request-based updates only
 - Combine `DEBUG_DATA` and `DEBUG_INFO` into single message type
 
-### 3. Smart Memory Caching (Medium Priority)
+### 3. Cache Memory Reads
 
 - Cache memory reads in components
 - Only re-request when PC changes significantly
 - Implement dirty tracking for memory modifications
 
-### 4. Visibility-Based Updates (Medium Priority)
+### 4. Only Update What's Visible
 
 - Track which debug tab is active
 - Only update visible components
 - Pause updates for hidden tabs
 
-### 5. Throttle Updates During Execution (Medium Priority)
+### 5. Slow Down Updates When Running
 
 - Reduce update frequency when running (not paused)
 - Increase frequency only during stepping/debugging
 - Use 500ms intervals for running state, 100ms for paused
 
-### 6. Batch Worker Messages (Low Priority)
+### 6. Bundle Messages Together
 
 - Combine multiple data requests into single message
 - Reduce message passing overhead
 
-## Implementation Plan
+## How I Might Fix This
 
-### Phase 1: Quick Wins
+### Easy Stuff First
 
-1. Make worker debug timer conditional on debugger visibility
-2. Remove duplicate DEBUG_INFO requests in DisassemblerPaginated when not paused
-3. Increase update interval to 250ms for running state
+1. Only run the debug timer when the debugger is actually open
+2. Stop the duplicate requests when not paused
+3. Use slower updates (250ms) when running
 
-### Phase 2: Architectural Improvements
+### Bigger Changes
 
-1. Implement debugger active state tracking
-2. Add visibility detection for debug tabs
-3. Create unified debug data request system
+1. Track when the debugger is active
+2. Know which tab is visible
+3. Make one unified way to request debug data
 
-### Phase 3: Advanced Optimizations
+### Fancy Stuff (Maybe Later)
 
-1. Implement memory caching layer
-2. Add dirty tracking for memory regions
-3. Create predictive prefetching for disassembly
+1. Cache memory reads
+2. Track which memory changed
+3. Pre-fetch disassembly before it's needed
 
-## Expected Results
+## What This Should Fix
 
-- 50-70% reduction in CPU usage when debugger is open
-- Near-zero overhead when debugger is closed
-- Smoother UI interactions during debugging
+- Cut CPU usage by half or more when debugging
+- Almost no overhead when debugger is closed
+- Smoother UI when stepping through code

--- a/docs/state_management_and_routing_analysis.md
+++ b/docs/state_management_and_routing_analysis.md
@@ -1,0 +1,328 @@
+# State Management and Routing Analysis
+
+_Date: December 2025_  
+_Analysis of current patterns and potential improvements_
+
+## Summary
+
+Apple1JS uses a simple, pragmatic approach to state management that works well. I've found some synchronization issues in cross-view navigation that would be good to fix. The current approach isn't broken - it just needs some targeted improvements to make it more robust.
+
+## Current Architecture
+
+### State Management
+
+1. **Worker-UI Separation** (Excellent Pattern ✅)
+   - Core emulation state lives in Web Worker
+   - UI state managed in React components
+   - Message-based communication prevents race conditions
+   - Clear separation of concerns
+
+2. **React Context for Cross-Cutting Concerns** (Good Pattern ✅)
+   - `LoggingContext`: Centralized logging with batched updates
+   - `DebuggerNavigationContext`: Cross-view navigation events
+   - Appropriate use of Context API for app-wide state
+
+3. **Component-Level State** (Appropriate ✅)
+   - Tab selection, UI preferences in `AppContent`
+   - Local state for component-specific needs
+   - No prop drilling issues
+
+### Navigation Architecture
+
+1. **Tab-Based Navigation** (Fit for Purpose ✅)
+   - Simple state-based tab switching
+   - No URL routing (appropriate for emulator)
+   - Three main views: Info, Inspector, Debugger
+
+2. **Cross-View Navigation via Context** (Has Issues ⚠️)
+   - `AddressLink` → `DebuggerNavigationContext` → Tab switch + Address navigation
+   - Works but has synchronization problems
+
+## Identified Pain Points
+
+### 1. Navigation Synchronization Issues 🔴
+
+**Problem**: Different components handle navigation differently, causing race conditions.
+
+```typescript
+// MemoryViewerPaginated: Only syncs once
+useEffect(() => {
+  if (initialAddress !== undefined && !hasInitialized.current) {
+    hasInitialized.current = true;
+    setCurrentAddress(initialAddress);
+  }
+}, [initialAddress]);
+
+// DisassemblerPaginated: Continuous sync with potential feedback loops
+useEffect(() => {
+  if (externalAddress !== undefined && externalAddress !== lastExternalAddress.current) {
+    lastExternalAddress.current = externalAddress;
+    navigateTo(externalAddress);
+  }
+}, [externalAddress, navigateTo]);
+```
+
+**Impact**:
+
+- Potential infinite loops when switching tabs
+- Inconsistent behavior between memory viewer and disassembler
+- Address changes might not propagate correctly
+
+### 2. Pending Navigation Pattern 🟡
+
+**Problem**: Complex handoff between components for navigation.
+
+```typescript
+// AppContent stores pending navigation
+const [pendingNavigation, setPendingNavigation] = useState<...>
+
+// DebuggerLayout receives and clears it
+initialNavigation={pendingNavigation}
+onNavigationHandled={() => setPendingNavigation(null)}
+```
+
+**Impact**:
+
+- Extra state management complexity
+- Potential for lost navigation events
+- Timing-dependent behavior
+
+### 3. No State Persistence 🟡
+
+**Current Behavior**:
+
+- Complete state loss on page refresh
+- No URL-based deep linking
+- Manual save/load only option
+
+**Impact**:
+
+- Users lose work on accidental refresh
+- Can't share specific debugger views
+- No progressive enhancement
+
+### 4. Event Listener Management in Context 🟡
+
+**Problem**: Direct array manipulation for listeners.
+
+```typescript
+setListeners(prev => [...prev, callback]);
+```
+
+**Impact**:
+
+- Recreates array on each subscription
+- Potential memory leaks if not cleaned up
+- Could use Map or Set for better performance
+
+## Ideas for Improvement
+
+### Worth Fixing Soon 🔧
+
+#### 1. Standardize Navigation Synchronization
+
+Create a unified navigation hook that handles the synchronization pattern consistently:
+
+```typescript
+// useNavigableComponent.ts
+export function useNavigableComponent(
+  externalAddress: number | undefined,
+  onAddressChange?: (address: number) => void
+) {
+  const [currentAddress, setCurrentAddress] = useState(0);
+  const [navigationSource, setNavigationSource] = useState<'external' | 'internal'>('external');
+  const lastExternalAddress = useRef<number>();
+
+  // Handle external navigation
+  useEffect(() => {
+    if (externalAddress !== undefined && 
+        externalAddress !== lastExternalAddress.current &&
+        navigationSource === 'external') {
+      lastExternalAddress.current = externalAddress;
+      setCurrentAddress(externalAddress);
+    }
+  }, [externalAddress, navigationSource]);
+
+  // Handle internal navigation
+  const navigateInternal = useCallback((address: number) => {
+    setNavigationSource('internal');
+    setCurrentAddress(address);
+    onAddressChange?.(address);
+    // Reset source after a tick
+    setTimeout(() => setNavigationSource('external'), 0);
+  }, [onAddressChange]);
+
+  return { currentAddress, navigateInternal };
+}
+```
+
+#### 2. Simplify Pending Navigation
+
+Instead of storing pending navigation in AppContent, handle it directly in DebuggerLayout:
+
+```typescript
+// DebuggerLayout.tsx
+const [hasHandledInitialNav, setHasHandledInitialNav] = useState(false);
+
+useEffect(() => {
+  const unsubscribe = subscribeToNavigation((event) => {
+    // Direct handling, no pending state needed
+    if (event.target === 'disassembly') {
+      setActiveView('disassembly');
+      setDisassemblerAddress(event.address);
+    } else if (event.target === 'memory') {
+      setActiveView('memory');
+      setMemoryViewAddress(event.address);
+    }
+  });
+  return unsubscribe;
+}, [subscribeToNavigation]);
+```
+
+### Nice to Have Features 📋
+
+#### 1. Add Optional URL State for Debugger
+
+Implement lightweight URL state for debugger views without adding a routing library:
+
+```typescript
+// useDebuggerUrlState.ts
+export function useDebuggerUrlState() {
+  const [state, setState] = useState(() => {
+    const hash = window.location.hash.slice(1);
+    const params = new URLSearchParams(hash);
+    return {
+      view: params.get('view') as DebugView || 'overview',
+      address: params.get('addr') ? parseInt(params.get('addr')!, 16) : undefined
+    };
+  });
+
+  const updateUrl = useCallback((view: DebugView, address?: number) => {
+    const params = new URLSearchParams();
+    params.set('view', view);
+    if (address !== undefined) {
+      params.set('addr', address.toString(16));
+    }
+    window.location.hash = params.toString();
+  }, []);
+
+  useEffect(() => {
+    const handleHashChange = () => {
+      const hash = window.location.hash.slice(1);
+      const params = new URLSearchParams(hash);
+      setState({
+        view: params.get('view') as DebugView || 'overview',
+        address: params.get('addr') ? parseInt(params.get('addr')!, 16) : undefined
+      });
+    };
+    window.addEventListener('hashchange', handleHashChange);
+    return () => window.removeEventListener('hashchange', handleHashChange);
+  }, []);
+
+  return { state, updateUrl };
+}
+```
+
+#### 2. Add Session Storage for UI Preferences
+
+```typescript
+// usePersistedState.ts
+export function usePersistedState<T>(key: string, defaultValue: T) {
+  const [value, setValue] = useState<T>(() => {
+    try {
+      const item = window.sessionStorage.getItem(key);
+      return item ? JSON.parse(item) : defaultValue;
+    } catch {
+      return defaultValue;
+    }
+  });
+
+  const setPersistedValue = useCallback((newValue: T | ((prev: T) => T)) => {
+    setValue(prev => {
+      const nextValue = typeof newValue === 'function' 
+        ? (newValue as (prev: T) => T)(prev) 
+        : newValue;
+      window.sessionStorage.setItem(key, JSON.stringify(nextValue));
+      return nextValue;
+    });
+  }, [key]);
+
+  return [value, setPersistedValue] as const;
+}
+
+// In AppContent
+const [rightTab, setRightTab] = usePersistedState('ui.rightTab', 'info');
+const [supportBS, setSupportBS] = usePersistedState('ui.supportBS', CONFIG.CRT_SUPPORT_BS);
+```
+
+### Future Possibilities 💭
+
+#### 1. Event Bus Pattern for Navigation
+
+If navigation becomes more complex, consider an event bus:
+
+```typescript
+class NavigationBus extends EventTarget {
+  navigate(address: number, target: NavigationTarget) {
+    this.dispatchEvent(new CustomEvent('navigate', { 
+      detail: { address, target } 
+    }));
+  }
+}
+
+export const navigationBus = new NavigationBus();
+```
+
+#### 2. State Machine for Complex Flows
+
+If we add breakpoints, watchpoints, and complex debugging:
+
+```typescript
+// Using XState or similar
+const debuggerMachine = createMachine({
+  initial: 'idle',
+  states: {
+    idle: {},
+    running: {},
+    paused: {},
+    stepInto: {},
+    stepOver: {},
+    runningToAddress: {}
+  }
+});
+```
+
+## What NOT to Do ❌
+
+1. **Don't add Redux/Zustand/MobX** - Current state management is sufficient
+2. **Don't add React Router** - URL routing adds complexity without clear benefit
+3. **Don't centralize all state** - Component-local state is working well
+4. **Don't rewrite the Worker communication** - Message passing is solid
+
+## Conclusion
+
+The current architecture is **fundamentally sound** but needs **targeted fixes** for navigation synchronization. The recommendations above will:
+
+1. Fix immediate bugs without major refactoring
+2. Add useful features (URL state, preference persistence) without complexity
+3. Prepare for future features without over-engineering
+
+**Key Principle**: Keep it simple. The focus is emulation accuracy, not complex UI state management. Any improvements should enhance the experience without compromising the simplicity that makes this codebase fun to work with.
+
+## Things to Explore
+
+**If the navigation bugs get annoying**:
+
+- [ ] Try the `useNavigableComponent` hook approach
+- [ ] Fix synchronization between MemoryViewer and Disassembler
+- [ ] Simplify the pending navigation pattern
+
+**Would be cool to have**:
+
+- [ ] URL state for sharing debugger views with others
+- [ ] Remember UI preferences between sessions
+
+**Maybe someday**:
+
+- [ ] Event bus if navigation gets more complex
+- [ ] State machine if we add complex debugging features

--- a/docs/ui_logging_refactor_design.md
+++ b/docs/ui_logging_refactor_design.md
@@ -36,9 +36,9 @@ When badges are clicked:
 2. **LoggingContext.tsx** - Add methods for getting counts by level
 3. Remove **StatusPanel** from inline display
 
-## Implementation Plan
+## How to Build It
 
-### Phase 1: Badge System
+### Badge System
 ```tsx
 // In App.tsx header area (after tab buttons)
 <div className="flex items-center gap-2 ml-auto">

--- a/docs/user_experience_analysis.md
+++ b/docs/user_experience_analysis.md
@@ -2,15 +2,15 @@
 
 ## Overview
 
-This document tracks UX/UI enhancements for Apple1JS, focusing on authentic emulation experience and powerful debugging tools for vintage computing enthusiasts and developers.
+This is where I keep notes about UX/UI improvements I've made or want to explore. The focus is on making the emulator feel authentic while adding useful debugging features.
 
-## Current State (July 2025)
+## What's Been Done (July 2025)
 
-### ✅ Phase 1: UI Layout & Design System (COMPLETED)
+### ✅ UI Layout & Design System
 
-**What we built**: Comprehensive design token system establishing visual consistency.
+**What I built**: A design token system to keep colors and spacing consistent.
 
-**Why it mattered**: Previously, colors and spacing were hardcoded throughout components, making theme changes impossible and creating visual inconsistency.
+**Why I did it**: Colors and spacing were hardcoded everywhere, making it a pain to change anything.
 
 **Key components**:
 
@@ -19,7 +19,7 @@ This document tracks UX/UI enhancements for Apple1JS, focusing on authentic emul
 - Design tokens in `src/styles/tokens.ts`
 - Typography scale for visual hierarchy
 
-### ✅ Phase 2: Visual Polish (COMPLETED)
+### ✅ Visual Polish
 
 **Advanced CRT Effects**: Authentic phosphor persistence, bloom, and barrel distortion.
 
@@ -30,7 +30,7 @@ This document tracks UX/UI enhancements for Apple1JS, focusing on authentic emul
 - Barrel distortion: CSS transforms
 - Performance: Maintains 60fps
 
-### ✅ Phase 3: Integrated Debugger (COMPLETED)
+### ✅ Integrated Debugger
 
 **Problem solved**: Initial debugger crammed everything into one view - users complained "too compressed".
 
@@ -40,19 +40,19 @@ This document tracks UX/UI enhancements for Apple1JS, focusing on authentic emul
 - **MemoryViewer**: 768-byte hex view with address navigation
 - **StackViewer**: Real-time 6502 stack monitor ($0100-$01FF)
 
-**Key learnings**:
+**What I learned**:
 
-- Users need focused views, not information density
-- Consistent navigation patterns matter (address input like disassembler)
-- Smart scrolling improves navigation (up=bottom, down=top)
+- People want focused views, not everything crammed together
+- Navigation should work the same way everywhere
+- Smart scrolling makes navigation feel better
 
-## Next Priority: Phase 4 - Advanced Debugging
+## Ideas to Explore Next
 
 ### Execution Control
 
-**Why critical**: Current debugger is read-only. Power users need precise control for debugging vintage software.
+**The goal**: The debugger is currently read-only. Would be cool to have precise control for debugging vintage software.
 
-**Tasks**:
+**Things to try**:
 
 - [x] Step-by-step execution (CPU already supports it) ✅
 - [x] Breakpoint UI with visual indicators ✅
@@ -60,55 +60,55 @@ This document tracks UX/UI enhancements for Apple1JS, focusing on authentic emul
 - [x] Run-to-cursor in disassembler ✅
 - [ ] Conditional breakpoints (e.g., "break when A=$FF")
 
-**Implementation notes**:
+**Notes to self**:
 
 - Worker messages exist: STEP, SET_BREAKPOINT
 - Need UI integration in DebuggerLayout
 - Store breakpoints in worker for performance
-- Auto-follow PC: Implemented to track PC during stepping, automatically navigates view when PC jumps outside visible range
+- Auto-follow PC: Done! It tracks PC during stepping and scrolls automatically
 
 ### Memory Analysis
 
-**Why critical**: Finding specific data in 64KB is tedious without search.
+**The problem**: Finding specific data in 64KB is tedious without search.
 
-**Tasks**:
+**Would be nice to have**:
 
 - [ ] Search for bytes/ASCII strings
 - [ ] Highlight results in MemoryViewer
 - [ ] Navigate between matches
 - [ ] Memory write support (UI ready, needs worker)
 
-**Implementation approach**:
+**How I might do it**:
 
 - Add search bar to MemoryViewer
 - Use worker for efficient searching
-- Maintain result indices for navigation
+- Keep track of results for navigation
 
 ### Watch Expressions
 
-**Why useful**: Monitor specific values without constantly navigating.
+**The idea**: Monitor specific values without constantly navigating.
 
-**Tasks**:
+**Features to explore**:
 
 - [ ] Add/remove watch expressions
 - [ ] Support memory addresses and registers
 - [ ] Update values in real-time
 
-## Phase 5: Hardware Authenticity
+## Fun Hardware Authenticity Ideas
 
 ### Audio Package
 
-**Quick wins for authenticity**:
+**Easy things that would add atmosphere**:
 
 - [ ] Keyboard click sounds (mechanical switches)
 - [ ] System beeps for errors
 - [ ] Volume controls
 
-**Implementation**: Web Audio API with pre-recorded samples
+**How to do it**: Web Audio API with pre-recorded samples
 
 ### Visual Enhancements
 
-**Complete the vintage experience**:
+**More vintage touches**:
 
 - [ ] Power-on sequence (degauss animation)
 - [ ] Activity LEDs for I/O operations
@@ -116,7 +116,7 @@ This document tracks UX/UI enhancements for Apple1JS, focusing on authentic emul
 
 ### Cassette Interface
 
-**Preserve software history**:
+**For preserving old software**:
 
 - [ ] Audio generation for tape save
 - [ ] WAV file loading support
@@ -142,31 +142,30 @@ This document tracks UX/UI enhancements for Apple1JS, focusing on authentic emul
 - Message batching reduces overhead
 - Virtual scrolling for large data sets
 
-## Known Issues & Technical Debt
+## Things That Bug Me
 
 1. **Memory Write**: UI complete but worker lacks implementation
 2. **Component Colors**: Some legacy components still hardcode colors
 3. **Markdown Formatting**: This file has linting warnings
 4. **Tab State Persistence**: ✅ FIXED - Views now maintain their address position when switching tabs
 
-## Success Metrics
+## Things I'm Happy About
 
-- ✅ 60fps with all effects enabled
-- ✅ Positive feedback on tabbed debugger
-- ✅ CRT effects match reference photos
-- ⏳ Execution control adoption (after implementation)
-- ⏳ Memory search usage metrics
+- ✅ Runs at 60fps with all effects enabled
+- ✅ People like the tabbed debugger layout
+- ✅ CRT effects look authentic compared to real photos
+- 💭 Curious to see if people will use execution control when I add it
+- 💭 Memory search seems like it would be really useful
 
-## Implementation Priority Order
+## What I'd Like to Work on Next (in rough order of coolness)
 
-1. **Execution Control** - Highest user value, enables precise debugging
-2. **Memory Search** - Most requested feature in feedback
-3. **Audio Effects** - Quick wins for authenticity
-4. **Watch Expressions** - Improves debugging workflow
-5. **Cassette Interface** - Preserves software history
+1. **Execution Control** - Would make debugging way more powerful
+2. **Memory Search** - People keep asking for this
+3. **Audio Effects** - Easy to add and would be fun
+4. **Watch Expressions** - Nice quality of life improvement
+5. **Cassette Interface** - Would be cool to load real Apple 1 software
 
 ## References
 
 - [6502 Instruction Set](http://www.6502.org/tutorials/6502opcodes.html)
 - [Apple 1 Memory Map](http://www.applefritter.com/node/2824)
-- Original user feedback threads (internal)

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '4.14.0';
+export const APP_VERSION = '4.14.1';


### PR DESCRIPTION
## Summary

Updated documentation language to better reflect the personal, hobby nature of this project.

## Changes

- Replaced formal corporate terminology with conversational language
- Updated CLAUDE.md with guidance about the project's personal nature
- Created state management analysis with informal tone
- Adjusted existing docs to remove references to sprints, phases, and priorities

The documentation now reads more like personal project notes rather than corporate engineering documents, while maintaining all the technical accuracy and useful information.

🤖 Generated with [Claude Code](https://claude.ai/code)