### PR TITLE
fix: restore paste functionality timing and add comprehensive tests

### DIFF
--- a/src/components/AppContent.tsx
+++ b/src/components/AppContent.tsx
@@ -62,15 +62,13 @@ export const AppContent = ({ worker, apple1Instance }: Props): JSX.Element => {
         async (e: ClipboardEvent) => {
             const text = e.clipboardData?.getData('text');
             if (text) {
-                const lines = text.split(/\r?\n/);
-                for (const line of lines) {
-                    for (const char of line) {
-                        worker.postMessage({ data: char, type: WORKER_MESSAGES.KEY_DOWN });
-                    }
-                    if (lines.length > 1) {
-                        worker.postMessage({ data: 'Enter', type: WORKER_MESSAGES.KEY_DOWN });
-                    }
-                }
+                // Send characters with a small delay between them to avoid overwhelming the Apple 1
+                text.split('').forEach((char, index) => {
+                    setTimeout(() => {
+                        const keyToSend = char === '\n' || char === '\r' ? 'Enter' : char;
+                        worker.postMessage({ data: keyToSend, type: WORKER_MESSAGES.KEY_DOWN });
+                    }, index * 160); // 160ms delay between each character
+                });
             }
             e.preventDefault();
         },

--- a/src/components/__tests__/AppContent.test.tsx
+++ b/src/components/__tests__/AppContent.test.tsx
@@ -1,0 +1,318 @@
+import '@testing-library/jest-dom/jest-globals';
+import { render, fireEvent, act } from '@testing-library/react';
+import { AppContent } from '../AppContent';
+import { WORKER_MESSAGES } from '../../apple1/TSTypes';
+
+// Mock child components
+jest.mock('../Info', () => ({
+    __esModule: true,
+    default: () => <div data-testid="info-component">Info Component</div>
+}));
+
+jest.mock('../InspectorView', () => ({
+    __esModule: true,
+    default: () => <div data-testid="inspector-component">Inspector Component</div>
+}));
+
+jest.mock('../DebuggerLayout', () => ({
+    __esModule: true,
+    default: () => <div data-testid="debugger-component">Debugger Component</div>
+}));
+
+jest.mock('../CRTWorker', () => ({
+    __esModule: true,
+    default: () => <div data-testid="crt-worker">CRT Worker</div>
+}));
+
+jest.mock('../Actions', () => ({
+    __esModule: true,
+    default: () => <div data-testid="actions">Actions</div>
+}));
+
+jest.mock('../AlertBadges', () => ({
+    __esModule: true,
+    default: () => <div data-testid="alert-badges">Alert Badges</div>
+}));
+
+jest.mock('../AlertPanel', () => ({
+    __esModule: true,
+    default: () => <div data-testid="alert-panel">Alert Panel</div>
+}));
+
+// Mock contexts
+jest.mock('../../contexts/LoggingContext', () => ({
+    useLogging: () => ({
+        addMessage: jest.fn()
+    })
+}));
+
+jest.mock('../../contexts/DebuggerNavigationContext', () => ({
+    useDebuggerNavigation: () => ({
+        subscribeToNavigation: jest.fn(() => () => {})
+    })
+}));
+
+interface MockWorker {
+    postMessage: jest.Mock;
+    addEventListener: jest.Mock;
+    removeEventListener: jest.Mock;
+}
+
+describe('AppContent', () => {
+    let mockWorker: MockWorker;
+
+    beforeEach(() => {
+        mockWorker = {
+            postMessage: jest.fn(),
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn()
+        };
+
+        // Mock timers for setTimeout tests
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+    });
+
+    describe('Paste Functionality', () => {
+        it('should handle paste events on the hidden input', async () => {
+            render(<AppContent worker={mockWorker as unknown as Worker} />);
+
+            const hiddenInput = document.querySelector('input[aria-label="Hidden input for keyboard focus"]');
+            expect(hiddenInput).toBeInTheDocument();
+
+            // Create clipboard event with text data
+            const pasteText = 'AB';
+
+            // Fire paste event using fireEvent.paste
+            act(() => {
+                fireEvent.paste(hiddenInput!, {
+                    clipboardData: {
+                        getData: () => pasteText
+                    }
+                });
+            });
+
+            // Clear any existing calls first
+            mockWorker.postMessage.mockClear();
+
+            // Fast-forward timers to trigger all setTimeout calls
+            act(() => {
+                jest.runAllTimers();
+            });
+
+
+            // Verify each character was sent with proper timing
+            expect(mockWorker.postMessage).toHaveBeenCalledTimes(2);
+            expect(mockWorker.postMessage).toHaveBeenCalledWith({
+                data: 'A',
+                type: WORKER_MESSAGES.KEY_DOWN
+            });
+            expect(mockWorker.postMessage).toHaveBeenCalledWith({
+                data: 'B',
+                type: WORKER_MESSAGES.KEY_DOWN
+            });
+        });
+
+        it('should handle newline characters in pasted text', async () => {
+            render(<AppContent worker={mockWorker as unknown as Worker} />);
+
+            const hiddenInput = document.querySelector('input[aria-label="Hidden input for keyboard focus"]');
+            const pasteText = 'A\nB';
+
+            act(() => {
+                fireEvent.paste(hiddenInput!, {
+                    clipboardData: {
+                        getData: () => pasteText
+                    }
+                });
+            });
+
+            // Clear any existing calls first
+            mockWorker.postMessage.mockClear();
+
+            act(() => {
+                jest.runAllTimers();
+            });
+
+            // Should send: A, Enter, B
+            expect(mockWorker.postMessage).toHaveBeenCalledTimes(3);
+            
+            // Check that newline becomes Enter
+            expect(mockWorker.postMessage).toHaveBeenCalledWith({
+                data: 'Enter',
+                type: WORKER_MESSAGES.KEY_DOWN
+            });
+        });
+
+        it('should handle carriage return characters in pasted text', async () => {
+            render(<AppContent worker={mockWorker as unknown as Worker} />);
+
+            const hiddenInput = document.querySelector('input[aria-label="Hidden input for keyboard focus"]');
+            const pasteText = 'A\rB';
+
+            act(() => {
+                fireEvent.paste(hiddenInput!, {
+                    clipboardData: {
+                        getData: () => pasteText
+                    }
+                });
+            });
+
+            // Clear any existing calls first
+            mockWorker.postMessage.mockClear();
+
+            act(() => {
+                jest.runAllTimers();
+            });
+
+            // Should send: A, Enter, B
+            expect(mockWorker.postMessage).toHaveBeenCalledTimes(3);
+            expect(mockWorker.postMessage).toHaveBeenCalledWith({
+                data: 'Enter',
+                type: WORKER_MESSAGES.KEY_DOWN
+            });
+        });
+
+        it('should handle empty paste events gracefully', async () => {
+            render(<AppContent worker={mockWorker as unknown as Worker} />);
+
+            const hiddenInput = document.querySelector('input[aria-label="Hidden input for keyboard focus"]');
+
+            act(() => {
+                fireEvent.paste(hiddenInput!, {
+                    clipboardData: {
+                        getData: () => ''
+                    }
+                });
+            });
+
+            // Clear any existing calls first
+            mockWorker.postMessage.mockClear();
+
+            act(() => {
+                jest.runAllTimers();
+            });
+
+            // Should not send any messages for empty paste
+            expect(mockWorker.postMessage).not.toHaveBeenCalled();
+        });
+
+        it('should handle paste events with no clipboardData', async () => {
+            render(<AppContent worker={mockWorker as unknown as Worker} />);
+
+            const hiddenInput = document.querySelector('input[aria-label="Hidden input for keyboard focus"]');
+            
+            act(() => {
+                fireEvent.paste(hiddenInput!, {
+                    clipboardData: {
+                        getData: () => null
+                    }
+                });
+            });
+
+            // Clear any existing calls first
+            mockWorker.postMessage.mockClear();
+
+            act(() => {
+                jest.runAllTimers();
+            });
+
+            // Should not send any messages when no clipboardData
+            expect(mockWorker.postMessage).not.toHaveBeenCalled();
+        });
+
+        it('should use correct timing delays between characters', async () => {
+            render(<AppContent worker={mockWorker as unknown as Worker} />);
+
+            const hiddenInput = document.querySelector('input[aria-label="Hidden input for keyboard focus"]');
+            const pasteText = 'ABC';
+
+            act(() => {
+                fireEvent.paste(hiddenInput!, {
+                    clipboardData: {
+                        getData: () => pasteText
+                    }
+                });
+            });
+
+            // Clear any existing calls first
+            mockWorker.postMessage.mockClear();
+
+            // Check that no messages are sent immediately
+            expect(mockWorker.postMessage).not.toHaveBeenCalled();
+
+            // Test timing - the first character should fire at 0ms delay (index 0 * 160)
+            // Second character at 160ms (index 1 * 160), third at 320ms (index 2 * 160)
+            
+            // Advance timer by 1ms - no characters should be sent yet since first is at 0ms already
+            act(() => {
+                jest.advanceTimersByTime(1);
+            });
+            expect(mockWorker.postMessage).toHaveBeenCalledTimes(1);
+            expect(mockWorker.postMessage).toHaveBeenLastCalledWith({
+                data: 'A',
+                type: WORKER_MESSAGES.KEY_DOWN
+            });
+
+            // Advance timer to 160ms (second character)
+            act(() => {
+                jest.advanceTimersByTime(159);
+            });
+            expect(mockWorker.postMessage).toHaveBeenCalledTimes(2);
+            expect(mockWorker.postMessage).toHaveBeenLastCalledWith({
+                data: 'B',
+                type: WORKER_MESSAGES.KEY_DOWN
+            });
+
+            // Advance timer to 320ms (third character)
+            act(() => {
+                jest.advanceTimersByTime(160);
+            });
+            expect(mockWorker.postMessage).toHaveBeenCalledTimes(3);
+            expect(mockWorker.postMessage).toHaveBeenLastCalledWith({
+                data: 'C',
+                type: WORKER_MESSAGES.KEY_DOWN
+            });
+        });
+    });
+
+    describe('Keyboard Functionality', () => {
+        it('should handle keydown events and ignore modifier keys', async () => {
+            render(<AppContent worker={mockWorker as unknown as Worker} />);
+
+            const hiddenInput = document.querySelector('input[aria-label="Hidden input for keyboard focus"]');
+
+            // Test normal key
+            act(() => {
+                fireEvent.keyDown(hiddenInput!, { key: 'A' });
+            });
+            expect(mockWorker.postMessage).toHaveBeenCalledWith({
+                data: 'A',
+                type: WORKER_MESSAGES.KEY_DOWN
+            });
+
+            mockWorker.postMessage.mockClear();
+
+            // Test modifier keys (should be ignored)
+            act(() => {
+                fireEvent.keyDown(hiddenInput!, { key: 'A', metaKey: true });
+            });
+            expect(mockWorker.postMessage).not.toHaveBeenCalled();
+
+            act(() => {
+                fireEvent.keyDown(hiddenInput!, { key: 'A', ctrlKey: true });
+            });
+            expect(mockWorker.postMessage).not.toHaveBeenCalled();
+
+            act(() => {
+                fireEvent.keyDown(hiddenInput!, { key: 'A', altKey: true });
+            });
+            expect(mockWorker.postMessage).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '4.15.0';
+export const APP_VERSION = '4.15.1';


### PR DESCRIPTION
## Summary

- Fixed critical paste functionality regression where characters were sent too fast to the Apple 1 emulator
- Restored proper 160ms timing delays between pasted characters for reliable processing
- Added comprehensive test suite to prevent future regressions

## Issues Fixed

- **Paste Regression**: Text pasting was broken due to missing character timing delays when code was refactored
- **Missing Test Coverage**: No tests existed to catch paste functionality regressions

## Changes Made

### Bug Fix (AppContent.tsx)
- Restored `setTimeout` with 160ms delays between characters in paste handler
- Maintains proper character flow that Apple 1 emulator can process
- Handles newlines and carriage returns correctly (converts to 'Enter')

### Test Coverage (AppContent.test.tsx)
- **7 comprehensive tests** covering all paste scenarios:
  - Basic text paste with proper character timing verification
  - Newline handling (`\n` → `Enter`)
  - Carriage return handling (`\r` → `Enter`)
  - Empty paste events (graceful no-op)
  - Missing clipboard data handling
  - Precise timing verification (160ms intervals)
  - Keyboard input with modifier key filtering

### Version Update
- Bumped to 4.15.1 (patch version for bug fix)

## Test Plan

- [x] All existing tests pass (`yarn run test:ci`)
- [x] New paste tests verify proper timing behavior
- [x] Manual testing confirms paste functionality works correctly
- [x] Edge cases handled gracefully (empty paste, missing data)

## Technical Details

The regression occurred when paste functionality was moved from `App.tsx` to `AppContent.tsx` but the critical timing delays were lost. The Apple 1 emulator requires 160ms between characters to process them correctly - without this timing, pasted text would overwhelm the system.

The new test suite uses Jest fake timers to precisely verify timing behavior and will catch any future regressions to this critical functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)