### PR TITLE
chore: harden CI workflow, add Dependabot + CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Code owners — branch protection requires code-owner review, so a PR that touches
+# any path below cannot merge without @stid's explicit approval. Deliberately NOT a
+# global `*` owner: ordinary src/ PRs still need the normal 1 review, but the
+# security-sensitive paths get the extra line-by-line gate described in SECURITY.md.
+
+# Claude Code tooling — can execute code on a maintainer's machine (see SECURITY.md)
+/.claude/        @stid
+
+# CI/CD, automation, and repo policy
+/.github/        @stid
+/SECURITY.md     @stid

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+# Dependabot version updates (security updates are enabled separately in repo settings).
+# Grouped + capped to keep PR noise low for a solo hobby project.
+version: 2
+updates:
+    # JavaScript/TypeScript (yarn) at the repo root
+    - package-ecosystem: npm
+      directory: /
+      schedule:
+          interval: weekly
+      open-pull-requests-limit: 5
+      groups:
+          npm-minor-patch:
+              update-types:
+                  - minor
+                  - patch
+
+    # Rust/WASM CPU engine
+    - package-ecosystem: cargo
+      directory: /wasm-cpu
+      schedule:
+          interval: weekly
+      open-pull-requests-limit: 5
+      groups:
+          cargo-minor-patch:
+              update-types:
+                  - minor
+                  - patch
+
+    # The GitHub Actions used in .github/workflows (keeps actions current)
+    - package-ecosystem: github-actions
+      directory: /
+      schedule:
+          interval: weekly
+      open-pull-requests-limit: 5
+      groups:
+          actions-all:
+              patterns:
+                  - '*'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,26 +2,30 @@ name: Tests CI
 
 on: [push, pull_request]
 
+# Least privilege: the only write this workflow needs is posting the `tests`
+# commit status (the curl steps below). Everything else is read-only.
+permissions:
+    contents: read
+    statuses: write
+
 jobs:
     test:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
-            
+
             - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
                   node-version-file: '.nvmrc'
-            
+
             - name: Setup Rust
-              uses: actions-rs/toolchain@v1
+              uses: dtolnay/rust-toolchain@stable
               with:
-                  toolchain: stable
-                  override: true
-                  target: wasm32-unknown-unknown
-            
+                  targets: wasm32-unknown-unknown
+
             - name: Cache Rust dependencies
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: |
                       ~/.cargo/bin/
@@ -32,21 +36,21 @@ jobs:
                   key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
                   restore-keys: |
                       ${{ runner.os }}-cargo-
-            
+
             - name: Install wasm-pack
               run: |
                   if ! command -v wasm-pack &> /dev/null; then
                       curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
                   fi
-            
+
             - name: Build WASM module
               run: |
                   cd wasm-cpu
                   wasm-pack build --dev --target web --out-dir ../src/wasm
-            
+
             - name: Install JS dependencies
               run: yarn install
-            
+
             - name: Run tests
               run: yarn test:ci
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '4.42.1';
+export const APP_VERSION = '4.42.2';


### PR DESCRIPTION
Repo-hardening pass for a public, fork-PR-accepting repo (deploys to stid.me via Netlify). Settings review surfaced four file-level gaps; this PR addresses them. Repo-level toggles (workflow token default, conversation resolution) are handled separately in settings.

## Changes

- **`main.yml` least privilege** — added `permissions: { contents: read, statuses: write }`. The workflow's only write need is posting the `tests` commit status. **This must merge before** the repo-level default token is dropped to read-only, or status posting breaks branch protection.
- **Replaced archived `actions-rs/toolchain@v1`** (unmaintained since 2022, deprecated Node runtime) with `dtolnay/rust-toolchain@stable`; bumped `actions/cache` v3 → v4.
- **Added `.github/dependabot.yml`** — version updates for npm, cargo (`/wasm-cpu`), and github-actions; grouped minor/patch, weekly, capped at 5 PRs/ecosystem.
- **Added `.github/CODEOWNERS`** — scopes code-owner review to `/.claude/` and `/.github/` + `SECURITY.md`, making the `SECURITY.md` line-by-line review policy actually enforce (branch protection already has `require_code_owner_reviews` on but no CODEOWNERS existed, so it was a no-op).
- **Version** 4.42.1 → 4.42.2.

## Notes
- Separately, GitHub flags **21 existing Dependabot vulnerability alerts** on `master` (2 critical / 11 high). Not addressed here — surfaced for a follow-up.

## Verification
- YAML validated (workflow + dependabot)
- `yarn type-check` ✅, `yarn lint` ✅
- CI (`tests`) runs on this PR with the new permissions block

🤖 Generated with [Claude Code](https://claude.com/claude-code)