### PR TITLE
fix: tighten parseAddressValue regex in RegisterRow

### DIFF
--- a/src/components/RegisterRow.tsx
+++ b/src/components/RegisterRow.tsx
@@ -32,7 +32,7 @@ export const RegisterRow: React.FC<RegisterRowProps> = ({
         if (typeof val === 'number') return val;
         if (typeof val === 'string') {
             // Handle formats like "$FF00" or "0xFF00"
-            const match = val.match(/^[$0x]*([0-9A-Fa-f]+)$/);
+            const match = val.match(/^(?:\$|0x)?([0-9A-Fa-f]+)$/i);
             if (match) {
                 return parseInt(match[1], 16);
             }

--- a/src/components/__tests__/RegisterRow.vitest.test.tsx
+++ b/src/components/__tests__/RegisterRow.vitest.test.tsx
@@ -1,7 +1,15 @@
-import { describe, expect } from 'vitest';
+import { describe, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { RegisterRow } from '../RegisterRow';
+import { createMockWorkerManager } from '../../test-support/mocks/WorkerManager.mock';
+
+// Mock navigation hook so AddressLink can render without a provider
+vi.mock('../../contexts/DebuggerNavigationContext', () => ({
+    useDebuggerNavigation: () => ({
+        navigate: vi.fn(),
+    }),
+}));
 
 describe('RegisterRow component', () => {
     it('should render label and value correctly', () => {
@@ -50,5 +58,24 @@ describe('RegisterRow component', () => {
 
         expect(screen.getByText('REG_A:')).toBeInTheDocument();
         expect(screen.queryByText('REG_A')).not.toBeInTheDocument();
+    });
+
+    it('should render a valid address value as an AddressLink', () => {
+        const workerManager = createMockWorkerManager();
+        render(<RegisterRow label="PC" value="$1234" type="address" workerManager={workerManager} />);
+
+        // AddressLink renders a button with the formatted address
+        const link = screen.getByRole('button');
+        expect(link).toHaveTextContent('$1234');
+    });
+
+    it('should NOT parse a malformed address value as an address', () => {
+        const workerManager = createMockWorkerManager();
+        render(<RegisterRow label="PC" value="x0$F" type="address" workerManager={workerManager} />);
+
+        // parseAddressValue returns null for the malformed input, so it falls
+        // through to a plain span instead of rendering a clickable AddressLink.
+        expect(screen.queryByRole('button')).not.toBeInTheDocument();
+        expect(screen.getByText('x0$F')).toHaveClass('text-data-address');
     });
 });

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '4.44.0';
+export const APP_VERSION = '4.44.1';


### PR DESCRIPTION
## Summary

The `parseAddressValue` regex in `src/components/RegisterRow.tsx` was `/^[$0x]*([0-9A-Fa-f]+)$/`, a character class that accepted arbitrary mixes of `$`, `0`, and `x` before the hex digits — so malformed input like `x0$F` was wrongly parsed as an address.

Tightened it to `/^(?:\$|0x)?([0-9A-Fa-f]+)$/i`, allowing only an optional single `$` or `0x` prefix. The `match[1]` capture group and `parseInt(match[1], 16)` logic are unchanged. When parsing now returns `null` for malformed input, `RegisterRow` falls through to a plain `<span>` instead of rendering a clickable `AddressLink`.

## Changes

- `src/components/RegisterRow.tsx` — tighten the regex
- `src/components/__tests__/RegisterRow.vitest.test.tsx` — add a test proving a valid value (`$1234`) still renders an `AddressLink`, and that the malformed value `x0$F` no longer parses as an address (renders as a plain span, no `button` role)
- `src/version.ts` — bump `4.43.0` → `4.43.1`

## Verification

- `yarn lint` ✅
- `yarn type-check` ✅
- `yarn test:ci` ✅ (694 passed, 18 skipped)

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Address input parsing now accepts optional "$" or "0x" prefixes and is case-insensitive, improving acceptance of various hex address formats.

* **Tests**
  * Enhanced tests to validate clickable address rendering when navigation is available and non-clickable fallback for malformed addresses.

* **Chores**
  * App version updated to 4.44.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stid/Apple1JS/pull/160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->