### PR TITLE
fix: make LOAD STATE keyboard-activatable (a11y)

### DIFF
--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 
 export type ActionsProps = {
     onReset: React.MouseEventHandler<HTMLAnchorElement>;
@@ -53,6 +53,7 @@ const Actions = ({
     const engineVariant = currentEngine === 'WASM' ? actionButtonVariant.success : actionButtonVariant.warning;
     const engineClassName = `${actionButtonBase} ${engineVariant}${engineToggleDisabled ? ' opacity-50 cursor-not-allowed' : ''}`;
 
+    const fileInputRef = useRef<HTMLInputElement>(null);
     return (
         <nav className="flex flex-wrap gap-sm justify-center">
             {/* Control Actions Group */}
@@ -91,18 +92,24 @@ const Actions = ({
             >
                 SAVE STATE
             </a>
-            <label className={`${actionButtonBase} ${actionButtonVariant.address}`} tabIndex={0}>
+            <button
+                type="button"
+                className={`${actionButtonBase} ${actionButtonVariant.address}`}
+                onClick={() => fileInputRef.current?.click()}
+            >
                 LOAD STATE
-                <input
-                    type="file"
-                    accept="application/json"
-                    style={{ display: 'none' }}
-                    onChange={(e) => {
-                        onLoadState(e);
-                        onRefocus();
-                    }}
-                />
-            </label>
+            </button>
+            <input
+                ref={fileInputRef}
+                type="file"
+                accept="application/json"
+                style={{ display: 'none' }}
+                aria-label="Load state from file"
+                onChange={(e) => {
+                    onLoadState(e);
+                    onRefocus();
+                }}
+            />
 
             {/* Configuration Group */}
             <a

--- a/src/components/__tests__/Actions.vitest.test.tsx
+++ b/src/components/__tests__/Actions.vitest.test.tsx
@@ -100,74 +100,84 @@ describe('Actions component', () => {
     });
 
     it('should call onLoadState when a file is selected', () => {
-        render(<Actions {...props} />);
-        const loadLabel = screen.getByText('LOAD STATE');
-        const input = loadLabel.querySelector('input[type="file"]') as HTMLInputElement;
-        
+        const { container } = render(<Actions {...props} />);
+        const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+
         const file = new File(['{}'], 'state.json', { type: 'application/json' });
         const changeEvent = { target: { files: [file] } };
-        
+
         fireEvent.change(input, changeEvent);
         expect(props.onLoadState).toHaveBeenCalledTimes(1);
         expect(props.onRefocus).toHaveBeenCalledTimes(1);
     });
 
+    it('should trigger the hidden file input click when "LOAD STATE" is clicked', () => {
+        const { container } = render(<Actions {...props} />);
+        const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+        const clickSpy = vi.spyOn(input, 'click');
+
+        fireEvent.click(screen.getByText('LOAD STATE'));
+
+        expect(clickSpy).toHaveBeenCalledTimes(1);
+        clickSpy.mockRestore();
+    });
+
     it('should handle hover states for buttons', () => {
         render(<Actions {...props} />);
         const resetAnchor = screen.getByText('RESET');
-        
+
         // Test mouse enter
         fireEvent.mouseEnter(resetAnchor);
         // The style should change but we can't directly test inline styles in jest-dom
-        
+
         // Test mouse leave
         fireEvent.mouseLeave(resetAnchor);
-        
+
         // Test other buttons for hover
         const pauseAnchor = screen.getByText('PAUSE');
         fireEvent.mouseEnter(pauseAnchor);
         fireEvent.mouseLeave(pauseAnchor);
-        
+
         const saveAnchor = screen.getByText('SAVE STATE');
         fireEvent.mouseEnter(saveAnchor);
         fireEvent.mouseLeave(saveAnchor);
-        
-        const loadLabel = screen.getByText('LOAD STATE');
-        fireEvent.mouseEnter(loadLabel);
-        fireEvent.mouseLeave(loadLabel);
-        
+
+        const loadButton = screen.getByText('LOAD STATE');
+        fireEvent.mouseEnter(loadButton);
+        fireEvent.mouseLeave(loadButton);
+
         const bsAnchor = screen.getByText('SUPPORT BACKSPACE [ON]');
         fireEvent.mouseEnter(bsAnchor);
         fireEvent.mouseLeave(bsAnchor);
-        
+
         const timingAnchor = screen.getByText('CYCLE TIMING [ACCURATE]');
         fireEvent.mouseEnter(timingAnchor);
         fireEvent.mouseLeave(timingAnchor);
-        
+
         // Verify all elements still exist after hover interactions
         expect(resetAnchor).toBeInTheDocument();
         expect(pauseAnchor).toBeInTheDocument();
         expect(saveAnchor).toBeInTheDocument();
-        expect(loadLabel).toBeInTheDocument();
+        expect(loadButton).toBeInTheDocument();
         expect(bsAnchor).toBeInTheDocument();
         expect(timingAnchor).toBeInTheDocument();
     });
 
     it('should call onRefocus when any action is triggered', () => {
         render(<Actions {...props} />);
-        
+
         // Reset
         fireEvent.click(screen.getByText('RESET'));
         expect(props.onRefocus).toHaveBeenCalledTimes(1);
-        
+
         // Pause
         fireEvent.click(screen.getByText('PAUSE'));
         expect(props.onRefocus).toHaveBeenCalledTimes(2);
-        
+
         // Backspace
         fireEvent.click(screen.getByText('SUPPORT BACKSPACE [ON]'));
         expect(props.onRefocus).toHaveBeenCalledTimes(3);
-        
+
         // Timing
         fireEvent.click(screen.getByText('CYCLE TIMING [ACCURATE]'));
         expect(props.onRefocus).toHaveBeenCalledTimes(4);
@@ -199,10 +209,9 @@ describe('Actions component', () => {
     });
 
     it('should render file input with correct attributes', () => {
-        render(<Actions {...props} />);
-        const loadLabel = screen.getByText('LOAD STATE');
-        const input = loadLabel.querySelector('input[type="file"]') as HTMLInputElement;
-        
+        const { container } = render(<Actions {...props} />);
+        const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+
         expect(input).toBeInTheDocument();
         expect(input.accept).toBe('application/json');
         expect(input.style.display).toBe('none');
@@ -210,18 +219,24 @@ describe('Actions component', () => {
 
     it('should have correct tabIndex on interactive elements', () => {
         render(<Actions {...props} />);
-        
+
         const interactiveElements = [
             screen.getByText('RESET'),
             screen.getByText('PAUSE'),
             screen.getByText('SAVE STATE'),
-            screen.getByText('LOAD STATE'),
             screen.getByText('SUPPORT BACKSPACE [ON]'),
-            screen.getByText('CYCLE TIMING [ACCURATE]')
+            screen.getByText('CYCLE TIMING [ACCURATE]'),
         ];
-        
-        interactiveElements.forEach(element => {
+
+        interactiveElements.forEach((element) => {
             expect(element).toHaveAttribute('tabIndex', '0');
         });
+
+        // LOAD STATE is a real <button> — natively focusable without an explicit tabIndex.
+        const loadButton = screen.getByText('LOAD STATE');
+        expect(loadButton.tagName).toBe('BUTTON');
+        expect(loadButton).not.toHaveAttribute('tabIndex');
+        loadButton.focus();
+        expect(loadButton).toHaveFocus();
     });
 });

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '4.44.1';
+export const APP_VERSION = '4.44.2';


### PR DESCRIPTION
## Summary

The "LOAD STATE" control in `src/components/Actions.tsx` was a focusable `<label tabIndex={0}>` wrapping a hidden file `<input>`. A focusable `<label>` as the primary action can block keyboard users from opening the file picker in some browsers.

This replaces it with a real `<button type="button">` that programmatically triggers a ref-driven hidden file input:

- The label is now a native `<button>` (no explicit `tabIndex` — buttons are natively focusable/activatable).
- The file `<input>` is now a sibling element driven by a `useRef`, clicked via `onClick={() => fileInputRef.current?.click()}`. It keeps `display: none`, `accept="application/json"`, and gains an `aria-label`.

## Tests

Updated `Actions.vitest.test.tsx` for the new DOM structure (input is now a sibling, not a child of the label):
- "should call onLoadState when a file is selected" and "should render file input with correct attributes" now query the input via `container.querySelector('input[type="file"]')`. The `display: none` and `accept` assertions are unchanged, and onLoadState + onRefocus are still asserted to fire on change.
- "should have correct tabIndex on interactive elements" no longer expects LOAD STATE in the `tabIndex='0'` loop; instead it asserts the element is a `<button>`, has no explicit `tabIndex`, and is focusable.
- Hover test variable renamed `loadLabel` → `loadButton` (functionally unchanged).

Version bumped to 4.43.2.

Gate: `yarn lint`, `yarn type-check`, and `yarn test:ci` (692 passed, 18 skipped) all pass.

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the "LOAD STATE" control interaction for better keyboard focus, click behavior, and accessibility.

* **Tests**
  * Updated tests to exercise the hidden file input and verify focus/hover behavior and expected tabbing changes.

* **Chores**
  * Version bumped to 4.44.2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stid/Apple1JS/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->