### PR TITLE
chore: audit component IVersionedStatefulComponent/IInspectableComponent applicability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,15 +126,21 @@ git push
 
 ## Key Patterns to Follow
 
-- **State management**: components implement `IVersionedStatefulComponent` with
-  version + migration support.
+- **State management**: _emulated-hardware_ classes (CPU, Bus, RAM, ROM, PIA,
+  Clock, Apple1) implement `IVersionedStatefulComponent` with version + migration
+  support. These contracts are **scoped to the core/IO layer, not React
+  components** — see the applicability rule + audit in
+  `docs/active/architecture.md` ("Where these contracts apply"). Presentational
+  components (`Actions`, `RegisterRow`, …) must NOT implement them.
 - **Formatting**: use the `Formatters` utility (e.g. `Formatters.hexWord(addr)`)
   — never manual `toString(16)`.
 - **Worker communication**: type-safe via
   `sendWorkerMessage(worker, WORKER_MESSAGES.SET_BREAKPOINT, address)`. Messages
   defined in `src/apple1/types/worker-messages.ts`.
-- **Component inspection**: implement `IInspectableComponent`; return structured
-  data from `getInspectable()` for debugger visibility.
+- **Component inspection**: emulated-hardware classes implement
+  `IInspectableComponent`; return structured data from `getInspectable()` for
+  debugger visibility. React components _consume_ the inspectable tree (they don't
+  implement it).
 
 ## UI Work
 

--- a/docs/active/architecture.md
+++ b/docs/active/architecture.md
@@ -191,6 +191,75 @@ interface IVersionedStatefulComponent<TState> {
 }
 ```
 
+### Where these contracts apply (and where they must NOT)
+
+`IInspectableComponent` and `IVersionedStatefulComponent` model the **emulated
+hardware tree** — they belong to the core/IO classes that own simulated state and
+appear in the debugger, NOT to the React presentation layer.
+
+**Rule of thumb — do NOT apply blanket:**
+
+- **Implement the contracts** when a class _is_ a piece of emulated hardware that:
+  - owns persisted/serializable state that must survive save/load and needs
+      versioned migration → `IVersionedStatefulComponent`, and/or
+  - exposes debug-inspectable state to the Inspector/architecture view →
+      `IInspectableComponent` (`getInspectable()`).
+- **Do NOT implement the contracts** on:
+  - React components in `src/components/**`. They render the UI and _consume_ the
+      inspectable tree (typically as an `apple1Instance: IInspectableComponent` prop);
+      they hold only ephemeral view state via hooks/contexts, which is not the
+      versioned-hardware state these contracts describe.
+  - Purely presentational / stateless helpers (e.g. `Actions`, `RegisterRow`,
+      `MetricCard`, the CRT render subtree).
+
+CodeRabbit's coding-guideline that flags missing contract implementations must be
+read with this scope: it is meaningful for new **core/IO hardware classes**, and a
+false positive for presentational React components.
+
+#### Current implementers (the only classes that should implement these)
+
+| Class      | File                        | `IInspectableComponent` | `IVersionedStatefulComponent` |
+| ---------- | --------------------------- | :---------------------: | :---------------------------: |
+| `Apple1`   | `src/apple1/index.ts`       |           ✅            |              ✅               |
+| `Bus`      | `src/core/Bus.ts`           |           ✅            |               —               |
+| `Clock`    | `src/core/Clock.ts`         |           ✅            |              ✅               |
+| `CPU6502`  | `src/core/cpu6502/core.ts`  |           ✅            |              ✅               |
+| `PIA6820`  | `src/core/PIA6820.ts`       |           ✅            |              ✅               |
+| `RAM`      | `src/core/RAM.ts`           |           ✅            |              ✅               |
+| `ROM`      | `src/core/ROM.ts`           |           ✅            |              ✅               |
+| `CRTVideo` | `src/apple1/WebCRTVideo.ts` |           ✅            |               —               |
+| `Keyboard` | `src/apple1/WebKeyboard.ts` |           ✅            |               —               |
+
+#### Component audit — `src/components/**` (none should implement the contracts)
+
+All entries below are React presentation / UI helpers. None own versioned hardware
+state or produce an inspectable node, so the contracts are **N/A** for every one.
+
+| Component                                                                                         | Role                                                                    |          Contracts apply?          |
+| ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | :--------------------------------: |
+| `App`                                                                                             | Root shell, passes `apple1Instance` prop                                |        N/A (presentational)        |
+| `AppContent`                                                                                      | Orchestration; calls worker `saveState`/`loadState` (delegates to core) |   N/A (no owned versioned state)   |
+| `Main`                                                                                            | Layout, threads `apple1Instance` prop                                   |        N/A (presentational)        |
+| `Actions`                                                                                         | Button + ref file-load control                                          |          N/A (stateless)           |
+| `AddressLink` / `SmartAddress`                                                                    | Address rendering / navigation                                          |        N/A (presentational)        |
+| `CompactCpuRegisters` / `RegisterRow`                                                             | Register display                                                        |        N/A (presentational)        |
+| `ExecutionControls` / `CompactExecutionControls`                                                  | Run/step buttons                                                        |        N/A (presentational)        |
+| `EngineSwitcher`                                                                                  | Engine toggle control                                                   |        N/A (presentational)        |
+| `CRT`, `CRTCursor`, `CRTRow`, `CRTRowChar`, `CRTRowCharRom`, `CRTWorker`, `CharRomCanvasRenderer` | CRT render subtree                                                      | N/A (presentational/render helper) |
+| `DebuggerLayout`                                                                                  | Debugger layout; consumes `root: IInspectableComponent`                 |           N/A (consumer)           |
+| `InspectorView` / `InspectTree`                                                                   | Render the inspectable tree (calls `getInspectable()` on the core root) |  N/A (consumer, not implementer)   |
+| `DisassemblerPaginated`                                                                           | Disassembly view                                                        |     N/A (view state via hooks)     |
+| `MemoryViewerPaginated`                                                                           | Memory view                                                             |     N/A (view state via hooks)     |
+| `StackViewer`                                                                                     | Stack view                                                              |        N/A (presentational)        |
+| `PaginatedTableView`                                                                              | Generic paginated table                                                 |        N/A (presentational)        |
+| `PerformanceMetrics` / `MetricCard`                                                               | Metrics display                                                         |        N/A (presentational)        |
+| `Info`                                                                                            | Static help text                                                        |        N/A (presentational)        |
+| `Error`                                                                                           | Error boundary fallback UI                                              |        N/A (presentational)        |
+
+**Audit result:** every core/IO class that needs the contracts already implements
+them, and no React component does (correctly). No contract was added or removed by
+this audit.
+
 ### IClockable
 
 Components that respond to clock cycles:
@@ -207,12 +276,12 @@ interface IClockable {
 
 The Apple 1 memory layout is faithfully reproduced:
 
-| Address Range | Size | Component | Description |
-|--------------|------|-----------|-------------|
-| $0000-$0FFF | 4KB | RAM Bank 1 | Main RAM (includes zero page, stack) |
-| $D010-$D013 | 4B | PIA 6820 | Keyboard and display I/O |
-| $E000-$EFFF | 4KB | RAM Bank 2 | Extended RAM (for BASIC) |
-| $FF00-$FFFF | 256B | ROM | WOZ Monitor |
+| Address Range | Size | Component  | Description                          |
+| ------------- | ---- | ---------- | ------------------------------------ |
+| $0000-$0FFF   | 4KB  | RAM Bank 1 | Main RAM (includes zero page, stack) |
+| $D010-$D013   | 4B   | PIA 6820   | Keyboard and display I/O             |
+| $E000-$EFFF   | 4KB  | RAM Bank 2 | Extended RAM (for BASIC)             |
+| $FF00-$FFFF   | 256B | ROM        | WOZ Monitor                          |
 
 ## Worker Communication
 
@@ -225,15 +294,15 @@ interface IWorkerAPI {
     pauseEmulation(): void;
     resumeEmulation(): void;
     step(): DebugData;
-    
+
     // Breakpoints
     setBreakpoint(address: number): number[];
     clearBreakpoint(address: number): number[];
-    
+
     // Memory operations
     readMemoryRange(start: number, length: number): number[];
     writeMemory(address: number, value: number): void;
-    
+
     // State management
     saveState(): EmulatorState;
     loadState(state: EmulatorState): void;

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '4.44.2';
+export const APP_VERSION = '4.44.3';


### PR DESCRIPTION
Closes #159

## What & why

CodeRabbit's coding-guideline flags components that don't implement
`IVersionedStatefulComponent` / `IInspectableComponent`. But those contracts
model the **emulated-hardware tree**, not the React presentation layer — applying
them blanket to UI components is a false positive. This PR audits the codebase,
documents the applicability rule, and records the per-component classification.

## Finding

Both contracts are implemented **only** by core/IO classes — and that is correct.
No React component in `src/components/**` implements (or should implement) them:
they render and *consume* the inspectable tree (typically via an
`apple1Instance: IInspectableComponent` prop) and hold only ephemeral view state
through hooks/contexts.

### Implementers (the only classes that should)

| Class | `IInspectableComponent` | `IVersionedStatefulComponent` |
|-------|:--:|:--:|
| `Apple1` (`src/apple1/index.ts`) | ✅ | ✅ |
| `Bus` (`src/core/Bus.ts`) | ✅ | — |
| `Clock` (`src/core/Clock.ts`) | ✅ | ✅ |
| `CPU6502` (`src/core/cpu6502/core.ts`) | ✅ | ✅ |
| `PIA6820` (`src/core/PIA6820.ts`) | ✅ | ✅ |
| `RAM` (`src/core/RAM.ts`) | ✅ | ✅ |
| `ROM` (`src/core/ROM.ts`) | ✅ | ✅ |
| `CRTVideo` (`src/apple1/WebCRTVideo.ts`) | ✅ | — |
| `Keyboard` (`src/apple1/WebKeyboard.ts`) | ✅ | — |

### Component audit — `src/components/**`

Every component is React presentation / a UI helper. **None** owns versioned
hardware state or produces an inspectable node, so the contracts are **N/A** for
all of them (including `Actions` and `RegisterRow`, which are stateless;
`AppContent` only delegates save/load to the worker/core; `InspectorView` /
`DebuggerLayout` *consume* the tree). Full per-component table is in
`docs/active/architecture.md`.

## The documented rule

- **Implement** the contracts on emulated-hardware classes that own
  persisted/versioned state (→ `IVersionedStatefulComponent`) and/or expose
  debug-inspectable state (→ `IInspectableComponent`).
- **Do NOT implement** them on React components or presentational/stateless
  helpers.

Documented in **`docs/active/architecture.md`** (new "Where these contracts apply"
section + implementer table + full component classification table) and the
**`CLAUDE.md`** "Key Patterns to Follow" wording was tightened from the blanket
"components implement …" to the scoped core/IO layer.

## What was implemented

Nothing in code — the audit found every contract correctly placed already. Per the
project's anti-overengineering rule, no contracts were added or removed. Deliverable
is the documented rule + classification. Version bumped 4.43.0 → 4.43.3.

## Checks

- `yarn lint` ✅
- `yarn type-check` ✅
- `yarn test:ci` ✅ (692 passed, 18 skipped — WASM parity/benchmark, gitignored artifacts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * App version bumped to 4.44.3

* **Documentation**
  * Clarified architecture and component responsibilities, explicitly separating emulated-hardware entities from UI/presentation components and refining guidance for component inspection and debugger visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stid/Apple1JS/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->