### PR TITLE
feat: make CRT button colors state-aware and semantically correct

### DIFF
--- a/docs/active/design-system.md
+++ b/docs/active/design-system.md
@@ -47,6 +47,7 @@ in `src/**` so colors can't sneak back in outside the token file.
 | `colors.address` / `value` / `flag` / `status`                 | `text-data-address`, `bg-data-value`, `text-data-flag`           |
 | `colors.dataHover.address` / `value`                           | `text-data-address-hover`, `bg-data-value-hover`                 |
 | `colors.success` / `warning` / `error` / `info`                | `text-success`, `bg-warning`, `border-error` (also `semantic-*`) |
+| `colors.toggleActive` / `toggleInactive`                       | `text-toggle-active`, `bg-toggle-inactive` (stateful ON/OFF)     |
 | `colors.phosphor.*`                                            | `text-phosphor-primary`, `bg-phosphor-glow`                      |
 | `colors.surface.{primary…quaternary,overlay}`                  | `bg-surface-primary`, `bg-surface-overlay`                       |
 | `colors.border.{primary,secondary,accent,subtle}`              | `border-border-primary`, `border-border-accent`                  |
@@ -67,6 +68,11 @@ in `src/**` so colors can't sneak back in outside the token file.
   maps them to `component-{ram,rom,bus,cpu,pia,io,clock}`. `CPU` and `CPU6502` share one
   value and both collapse to `component-cpu`. `InspectorView.getComponentColor` mirrors
   this map for runtime `node.type` → class lookups.
+- **`toggle-active` / `toggle-inactive` carry state, not just a hue:** use them when a
+  control's colour should reflect a boolean ON/OFF (e.g. the `SUPPORT BACKSPACE` and
+  `CYCLE TIMING` buttons in `Actions.tsx`) — blue when enabled, neutral gray when off.
+  Keep them distinct from `success` (momentary command buttons) and `warning` (reserved
+  for genuine alerts), so a single colour never means two different things in one view.
 
 ## The CRT exception
 

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -28,7 +28,18 @@ const actionButtonVariant = {
     // Address actions are green (data-address token) — fixes the prior blue/green split.
     address:
         'bg-data-address/10 hover:bg-data-address/20 border-data-address/30 hover:border-data-address text-data-address',
-    warning: 'bg-warning/10 hover:bg-warning/20 border-warning/30 hover:border-warning text-warning',
+    // hover:text-* pins the on-token colour: the global `a:hover` rule in index.css
+    // (phosphor green) otherwise out-specifies the plain text utility and turns these
+    // non-green buttons green under the cursor, defeating the semantic.
+    warning: 'bg-warning/10 hover:bg-warning/20 border-warning/30 hover:border-warning text-warning hover:text-warning',
+    // Stateful toggles: blue when the feature is ON, neutral gray when OFF, so the
+    // colour itself reads the state at a glance (text label is now confirmation).
+    toggleOn:
+        'bg-toggle-active/10 hover:bg-toggle-active/20 border-toggle-active/30 hover:border-toggle-active text-toggle-active hover:text-toggle-active',
+    toggleOff:
+        'bg-toggle-inactive/10 hover:bg-toggle-inactive/20 border-toggle-inactive/30 hover:border-toggle-inactive text-toggle-inactive hover:text-toggle-inactive',
+    // Informational: the active engine is a neutral choice, not a success or a warning.
+    info: 'bg-info/10 hover:bg-info/20 border-info/30 hover:border-info text-info hover:text-info',
 } as const;
 
 const Actions = ({
@@ -49,8 +60,10 @@ const Actions = ({
 }: ActionsProps) => {
     // Nothing to toggle to when WASM is unavailable, and mid-switch clicks are ignored.
     const engineToggleDisabled = !wasmAvailable || isSwitchingEngine;
-    // Colour by active engine so the choice reads at a glance: green=WASM, amber=JS.
-    const engineVariant = currentEngine === 'WASM' ? actionButtonVariant.success : actionButtonVariant.warning;
+    // Both engines are valid choices, so the engine reads as informational (blue), not
+    // success/warning. Amber is reserved for the one genuine problem: WASM failed to
+    // load, so we're stuck on JS. A mid-switch is transient — just dim the info colour.
+    const engineVariant = !wasmAvailable ? actionButtonVariant.warning : actionButtonVariant.info;
     const engineClassName = `${actionButtonBase} ${engineVariant}${engineToggleDisabled ? ' opacity-50 cursor-not-allowed' : ''}`;
 
     const fileInputRef = useRef<HTMLInputElement>(null);
@@ -118,7 +131,7 @@ const Actions = ({
                     onRefocus();
                 }}
                 href="#"
-                className={`${actionButtonBase} ${actionButtonVariant.warning}`}
+                className={`${actionButtonBase} ${supportBS ? actionButtonVariant.toggleOn : actionButtonVariant.toggleOff}`}
                 tabIndex={0}
             >
                 SUPPORT BACKSPACE [{supportBS ? 'ON' : 'OFF'}]
@@ -129,7 +142,7 @@ const Actions = ({
                     onRefocus();
                 }}
                 href="#"
-                className={`${actionButtonBase} ${actionButtonVariant.warning}`}
+                className={`${actionButtonBase} ${cycleAccurateTiming ? actionButtonVariant.toggleOn : actionButtonVariant.toggleOff}`}
                 tabIndex={0}
             >
                 CYCLE TIMING [{cycleAccurateTiming ? 'ACCURATE' : 'FAST'}]

--- a/src/components/Actions.tsx
+++ b/src/components/Actions.tsx
@@ -38,8 +38,6 @@ const actionButtonVariant = {
         'bg-toggle-active/10 hover:bg-toggle-active/20 border-toggle-active/30 hover:border-toggle-active text-toggle-active hover:text-toggle-active',
     toggleOff:
         'bg-toggle-inactive/10 hover:bg-toggle-inactive/20 border-toggle-inactive/30 hover:border-toggle-inactive text-toggle-inactive hover:text-toggle-inactive',
-    // Informational: the active engine is a neutral choice, not a success or a warning.
-    info: 'bg-info/10 hover:bg-info/20 border-info/30 hover:border-info text-info hover:text-info',
 } as const;
 
 const Actions = ({
@@ -60,10 +58,14 @@ const Actions = ({
 }: ActionsProps) => {
     // Nothing to toggle to when WASM is unavailable, and mid-switch clicks are ignored.
     const engineToggleDisabled = !wasmAvailable || isSwitchingEngine;
-    // Both engines are valid choices, so the engine reads as informational (blue), not
-    // success/warning. Amber is reserved for the one genuine problem: WASM failed to
-    // load, so we're stuck on JS. A mid-switch is transient — just dim the info colour.
-    const engineVariant = !wasmAvailable ? actionButtonVariant.warning : actionButtonVariant.info;
+    // The engine button reads as a feature toggle: WASM is the "power", so WASM=on (blue),
+    // JS=off (gray). Amber is reserved for the one genuine problem — WASM failed to load,
+    // so we're stuck on JS. A mid-switch is transient and just dims the current colour.
+    const engineVariant = !wasmAvailable
+        ? actionButtonVariant.warning
+        : currentEngine === 'WASM'
+          ? actionButtonVariant.toggleOn
+          : actionButtonVariant.toggleOff;
     const engineClassName = `${actionButtonBase} ${engineVariant}${engineToggleDisabled ? ' opacity-50 cursor-not-allowed' : ''}`;
 
     const fileInputRef = useRef<HTMLInputElement>(null);

--- a/src/components/__tests__/Actions.vitest.test.tsx
+++ b/src/components/__tests__/Actions.vitest.test.tsx
@@ -233,15 +233,15 @@ describe('Actions component', () => {
         expect(screen.getByText('CYCLE TIMING [FAST]')).toHaveClass('text-toggle-inactive');
     });
 
-    it('should color the ENGINE button as informational (not a warning) for either engine', () => {
+    it('should color the ENGINE button as a WASM-power toggle: WASM on (blue), JS off (gray)', () => {
         const { rerender } = render(<Actions {...props} currentEngine="WASM" />);
         const wasmAnchor = screen.getByText('ENGINE [WASM]');
-        expect(wasmAnchor).toHaveClass('text-info');
+        expect(wasmAnchor).toHaveClass('text-toggle-active');
         expect(wasmAnchor).not.toHaveClass('text-warning');
 
         rerender(<Actions {...props} currentEngine="JS" />);
         const jsAnchor = screen.getByText('ENGINE [JS]');
-        expect(jsAnchor).toHaveClass('text-info');
+        expect(jsAnchor).toHaveClass('text-toggle-inactive');
         expect(jsAnchor).not.toHaveClass('text-warning');
     });
 

--- a/src/components/__tests__/Actions.vitest.test.tsx
+++ b/src/components/__tests__/Actions.vitest.test.tsx
@@ -217,6 +217,41 @@ describe('Actions component', () => {
         expect(input.style.display).toBe('none');
     });
 
+    it('should color SUPPORT BACKSPACE by its ON/OFF state', () => {
+        const { rerender } = render(<Actions {...props} supportBS={true} />);
+        expect(screen.getByText('SUPPORT BACKSPACE [ON]')).toHaveClass('text-toggle-active');
+
+        rerender(<Actions {...props} supportBS={false} />);
+        expect(screen.getByText('SUPPORT BACKSPACE [OFF]')).toHaveClass('text-toggle-inactive');
+    });
+
+    it('should color CYCLE TIMING by its ACCURATE/FAST state', () => {
+        const { rerender } = render(<Actions {...props} cycleAccurateTiming={true} />);
+        expect(screen.getByText('CYCLE TIMING [ACCURATE]')).toHaveClass('text-toggle-active');
+
+        rerender(<Actions {...props} cycleAccurateTiming={false} />);
+        expect(screen.getByText('CYCLE TIMING [FAST]')).toHaveClass('text-toggle-inactive');
+    });
+
+    it('should color the ENGINE button as informational (not a warning) for either engine', () => {
+        const { rerender } = render(<Actions {...props} currentEngine="WASM" />);
+        const wasmAnchor = screen.getByText('ENGINE [WASM]');
+        expect(wasmAnchor).toHaveClass('text-info');
+        expect(wasmAnchor).not.toHaveClass('text-warning');
+
+        rerender(<Actions {...props} currentEngine="JS" />);
+        const jsAnchor = screen.getByText('ENGINE [JS]');
+        expect(jsAnchor).toHaveClass('text-info');
+        expect(jsAnchor).not.toHaveClass('text-warning');
+    });
+
+    it('should warn (amber) and disable the ENGINE button when WASM is unavailable', () => {
+        render(<Actions {...props} currentEngine="JS" wasmAvailable={false} />);
+        const engineAnchor = screen.getByText('ENGINE [JS]');
+        expect(engineAnchor).toHaveClass('text-warning');
+        expect(engineAnchor).toHaveClass('cursor-not-allowed');
+    });
+
     it('should have correct tabIndex on interactive elements', () => {
         render(<Actions {...props} />);
 

--- a/src/styles/tailwind-tokens.ts
+++ b/src/styles/tailwind-tokens.ts
@@ -26,11 +26,15 @@ export const tokenDerivedTheme = {
         warning: colors.warning,
         error: colors.error,
         info: colors.info,
+        'toggle-active': colors.toggleActive,
+        'toggle-inactive': colors.toggleInactive,
         semantic: {
             success: colors.success,
             warning: colors.warning,
             error: colors.error,
             info: colors.info,
+            toggleActive: colors.toggleActive,
+            toggleInactive: colors.toggleInactive,
         },
 
         // Apple 1 phosphor theme

--- a/src/styles/tokens.ts
+++ b/src/styles/tokens.ts
@@ -54,6 +54,11 @@ export const designTokens = {
         error: '#EF4444', // Red for errors
         info: '#3B82F6', // Blue for informational
 
+        // Toggle states — color encodes a stateful feature's ON/OFF, kept distinct
+        // from `success` (momentary actions) and `warning` (genuine alerts).
+        toggleActive: '#3B82F6', // Blue — feature enabled / active selection
+        toggleInactive: '#6B7280', // Neutral gray — feature disabled (matches neutral.500)
+
         // Apple 1 phosphor green theme
         phosphor: {
             primary: '#00FF00', // Bright green

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '4.44.3';
+export const APP_VERSION = '4.45.0';


### PR DESCRIPTION
## Why

The button row under the CRT used only **green** and **amber**, with each color carrying two unrelated meanings:

- The config toggles (`SUPPORT BACKSPACE`, `CYCLE TIMING`) were **statically amber** regardless of ON/OFF — color told you nothing about state; only the `[ON]/[OFF]` text did.
- `ENGINE [JS]` was amber, implying a perfectly valid fallback engine is a *warning*. Amber = warning in color language, so it meant two contradictory things at once.

## What

A coherent, state-bound color language where no color means two things:

| Color | Meaning | Buttons |
|---|---|---|
| 🟢 Green | momentary command | RESET, PAUSE, SAVE/LOAD |
| 🔵 Blue | feature **ON** | BACKSPACE [ON], CYCLE TIMING [ACCURATE], ENGINE [WASM] |
| ⚪ Gray | feature **OFF** | BACKSPACE [OFF], CYCLE TIMING [FAST], ENGINE [JS] |
| 🟠 Amber | genuine warning only | ENGINE when WASM unavailable |

The ENGINE button is reframed as a **WASM-power toggle**: WASM = acceleration on (blue), JS = off (gray) — sharing the same `toggleOn`/`toggleOff` semantic as the other toggles rather than being a separate category.

### Changes
- Add semantic tokens `toggleActive` / `toggleInactive` to `tokens.ts` and the Tailwind adapter; the existing token-parity test auto-covers them (no `tailwind.config` edit needed).
- Bind toggle color to state in `Actions.tsx`; rework engine color logic.
- **Bug found during visual review:** a global `a:hover` rule in `index.css` (phosphor green) out-specifies the plain text utility and turned every button green *on hover*, silently defeating the scheme at the moment of interaction. Fixed by pinning `hover:text-*` on the non-green variants.
- Removed the now-unused `info` variant.
- Documented the toggle tokens in `design-system.md`.

## Verification
- `yarn lint` ✅ · `yarn type-check` ✅ · `yarn test:ci` ✅ (703 passing) · `yarn lint:md:fix` ✅
- New `Actions` tests assert the state→class binding (ON→`text-toggle-active`, OFF→`text-toggle-inactive`, WASM-unavailable→`text-warning`).
- Visually confirmed in-app (Chrome): toggles flip blue↔gray, ENGINE blue on WASM / gray on JS, amber reserved for WASM-unavailable, and colors hold on hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated design system guidance for toggle state tokens and naming conventions.

* **New Features**
  * Added dedicated toggle active/inactive color tokens and styling.

* **Bug Fixes**
  * Refined button hover states and improved engine selection logic to correctly represent ON/OFF states.
  * Updated "Support Backspace" and "Cycle Timing" buttons with proper toggle styling.

* **Tests**
  * Added coverage for UI state styling behavior.

* **Chores**
  * Version bumped to 4.45.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stid/Apple1JS/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->