### PR TITLE
chore: gitignore local-only SDD adapter artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ wasm-cpu/target/
 .claude/hooks/
 # Claude Code — native parallel worktrees live here (claude --worktree <name>)
 .claude/worktrees/
+# Spec-Driven Development — local-only adapter + artifacts (depend on the maintainer's
+# private global /stid-sdd-* tooling; not portable, so never committed to this public repo)
+.claude/rules/sdd-conventions.md
+docs/specs/


### PR DESCRIPTION
## What

Adds two `.gitignore` entries so the maintainer's local Spec-Driven Development (SDD) adapter never gets committed to this public repo:

- `.claude/rules/sdd-conventions.md`
- `docs/specs/`

## Why

These artifacts are read by / generated for a **private** global `/stid-sdd-*` tooling suite (lives in `~/claude-base`, not part of this project). They hard-code machine-specific paths and reference commands no other contributor has, so they aren't portable. Ignoring them keeps the public repo clean and prevents an accidental `git add -A` from leaking local tooling.

No source code or behavior changes — `.gitignore` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `.gitignore` to exclude additional local development artifacts and documentation paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stid/Apple1JS/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->