### PR TITLE
feat: authentic Apple 1 power-on noise screen (cleared by TAB/reset)

### DIFF
--- a/src/apple1/WebCRTVideo.ts
+++ b/src/apple1/WebCRTVideo.ts
@@ -8,6 +8,28 @@ import { IoComponent, PubSub, subscribeFunction } from '@/core/types';
 const NUM_COLUMNS = 40;
 const NUM_ROWS = 24;
 
+// Apple-1 displayable character set (space..underscore). On a real Apple 1 the
+// video RAM powered up in an indeterminate state with no routine to clear it, so
+// the screen showed a field of "junk" until the user reset/cleared it. We emulate
+// that cold-start by filling each cell with a random glyph from this range; the
+// character ROM (apple1vid.ts) renders every code in it.
+const POWERON_CHAR_MIN = 0x20;
+const POWERON_CHAR_MAX = 0x5f;
+
+function powerOnNoiseBuffer(): VideoBuffer {
+    const span = POWERON_CHAR_MAX - POWERON_CHAR_MIN + 1;
+    return Array.from(
+        { length: NUM_ROWS },
+        (_, i) =>
+            [
+                i,
+                Array.from({ length: NUM_COLUMNS }, () =>
+                    String.fromCharCode(POWERON_CHAR_MIN + Math.floor(Math.random() * span)),
+                ),
+            ] as [number, string[]],
+    );
+}
+
 // NOTE: WOZ monitor will wait in a loop until DSP B7 is clear and another char
 // was echoed.
 // DISPLAY_DELAY will in fact slow down the effective execution as the
@@ -24,7 +46,6 @@ const NUM_ROWS = 24;
 // On Apple 1 the display logic, including scroll was entirely hardware driven.
 // The CPU was free to execute in the meantime. In fact Apple 1 was faster than
 // the Apple II in this sense.
-
 
 function cloneBuffer(buffer: VideoBuffer): VideoBuffer {
     // Deep clone: each row and its data array
@@ -78,8 +99,8 @@ class CRTVideo implements IoComponent<VideoState>, PubSub<WebCrtVideoSubFuncVide
                 column: this.column,
                 supportBS: this.supportBS,
                 rowShift: this.rowShift,
-                bufferSize: this.buffer.length
-            }
+                bufferSize: this.buffer.length,
+            },
         };
     }
     row: number;
@@ -94,7 +115,7 @@ class CRTVideo implements IoComponent<VideoState>, PubSub<WebCrtVideoSubFuncVide
         this.column = 0;
         this.rowShift = 0;
         this.supportBS = CONFIG.CRT_SUPPORT_BS;
-        this.buffer = Array.from({ length: NUM_ROWS }, (_, i) => [i, Array(NUM_COLUMNS).fill('@')]);
+        this.buffer = powerOnNoiseBuffer();
         this.subscribers = [];
     }
 

--- a/src/apple1/WorkerAPI.ts
+++ b/src/apple1/WorkerAPI.ts
@@ -509,6 +509,14 @@ export class WorkerAPI implements IWorkerAPI {
 
     onVideoUpdate(callback: (data: VideoData) => void): () => void {
         this.videoCallbacks.add(callback);
+        // Deliver the current frame immediately: the power-on screen is emitted
+        // before any subscriber registers, so a late subscriber (e.g. React mounting
+        // after the worker booted) would otherwise never see it until the next write.
+        const video = this.workerState.video;
+        if (video && typeof video.getState === 'function') {
+            const { buffer, row, column } = video.getState();
+            callback({ buffer, row, column });
+        }
         return () => {
             this.videoCallbacks.delete(callback);
         };

--- a/src/apple1/__tests__/WebCRTVideo-power-on-noise-screen.vitest.test.ts
+++ b/src/apple1/__tests__/WebCRTVideo-power-on-noise-screen.vitest.test.ts
@@ -1,0 +1,72 @@
+/**
+ * SDD Phase 4 — power-on-noise-screen
+ *
+ * Failing tests generated from docs/specs/power-on-noise-screen/spec.md.
+ * RENDER surface, video component (WebCRTVideo). See plan.md cross-path matrix.
+ */
+import { describe, test, expect } from 'vitest';
+import WebCRTVideo from '../WebCRTVideo';
+
+const NUM_COLUMNS = 40;
+const NUM_ROWS = 24;
+const DATA = 1; // WEB_VIDEO_BUFFER_ROW.DATA — each row is [rowIndex, chars[]]
+
+// Apple-1 displayable character set: space..underscore.
+const CHAR_MIN = 0x20;
+const CHAR_MAX = 0x5f;
+
+describe('power-on-noise-screen — CRTVideo', () => {
+    test('AC-1 (RENDER): power-on fills 24x40 with displayable glyphs', () => {
+        const video = new WebCRTVideo();
+        const { buffer } = video.getState();
+
+        expect(buffer.length).toBe(NUM_ROWS);
+        for (const [, chars] of buffer) {
+            expect(chars.length).toBe(NUM_COLUMNS);
+            for (const ch of chars) {
+                expect(ch.length).toBe(1);
+                const code = ch.charCodeAt(0);
+                expect(code).toBeGreaterThanOrEqual(CHAR_MIN);
+                expect(code).toBeLessThanOrEqual(CHAR_MAX);
+            }
+        }
+    });
+
+    test('AC-2 (RENDER): two power-ons differ', () => {
+        const a = new WebCRTVideo().getState().buffer;
+        const b = new WebCRTVideo().getState().buffer;
+
+        const flat = (buf: typeof a) => buf.map(([, chars]) => chars.join('')).join('');
+        // Randomized per power-on: two independent cold-starts must not be identical.
+        expect(flat(a)).not.toBe(flat(b));
+    });
+
+    test('AC-3 (RENDER): reset clears screen to blank', () => {
+        const video = new WebCRTVideo();
+        video.reset();
+        const { buffer, row, column } = video.getState();
+
+        expect(row).toBe(0);
+        expect(column).toBe(0);
+        for (const [, chars] of buffer) {
+            for (const ch of chars) {
+                expect(ch).toBe(' ');
+            }
+        }
+    });
+
+    test('AC-5 (RENDER): a write leaves surrounding noise intact', async () => {
+        const video = new WebCRTVideo();
+        const before = video.getState().buffer;
+        const neighborBefore = before[0][DATA][1];
+        const rowOneBefore = before[1][DATA].join('');
+
+        // Write 'A' (0x41) to the top-left cell. write() masks bit 7, so 0x41 -> 'A'.
+        await video.write(0x41);
+
+        const after = video.getState().buffer;
+        expect(after[0][DATA][0]).toBe('A'); // targeted cell changed
+        expect(after[0][DATA][1]).toBe(neighborBefore); // adjacent cell untouched
+        expect(after[1][DATA].join('')).toBe(rowOneBefore); // next row untouched
+    });
+});

--- a/src/apple1/__tests__/WebCRTVideo.vitest.test.ts
+++ b/src/apple1/__tests__/WebCRTVideo.vitest.test.ts
@@ -18,12 +18,21 @@ describe('WebCRTVideo', function () {
         expect(webCRTVideo.column).toBe(0);
     });
 
-    test('Should Init with Cold State', function () {
-        const compBuffer = Array(NUM_ROWS);
-        for (let i = 0; i < compBuffer.length; i++) {
-            compBuffer[i] = [i, Array(NUM_COLUMNS).fill('@')];
+    test('Should Init with Cold State (power-on noise)', function () {
+        // Authentic Apple 1 cold-start: the buffer powers up full of random junk
+        // glyphs from the displayable set (0x20..0x5f), not a cleared screen.
+        const { buffer, row, column } = webCRTVideo.getState();
+        expect(row).toBe(0);
+        expect(column).toBe(0);
+        expect(buffer.length).toBe(NUM_ROWS);
+        for (const [, chars] of buffer) {
+            expect(chars.length).toBe(NUM_COLUMNS);
+            for (const ch of chars) {
+                const code = ch.charCodeAt(0);
+                expect(code).toBeGreaterThanOrEqual(0x20);
+                expect(code).toBeLessThanOrEqual(0x5f);
+            }
         }
-        expect(onChange).toHaveBeenCalledWith({ buffer: compBuffer, column: 0, row: 0 });
     });
 
     test('Should Reset', function () {

--- a/src/apple1/__tests__/WorkerAPI-power-on-noise-screen.vitest.test.ts
+++ b/src/apple1/__tests__/WorkerAPI-power-on-noise-screen.vitest.test.ts
@@ -1,0 +1,48 @@
+/**
+ * SDD Phase 4 — power-on-noise-screen (AC-4)
+ *
+ * The regression: a display observer that subscribes after power-on must receive
+ * the current on-screen frame immediately, otherwise the cold-start noise screen
+ * (emitted before any React subscriber registered) is never shown.
+ * RENDER surface, WorkerAPI. See plan.md cross-path matrix.
+ */
+import { describe, test, expect } from 'vitest';
+import { WorkerAPI } from '../WorkerAPI';
+import type { WorkerState } from '../WorkerState';
+import WebCRTVideo from '../WebCRTVideo';
+import type { VideoData } from '../TSTypes';
+
+/** Build a WorkerAPI over a hand-rolled WorkerState fake with a real video. */
+function makeWorkerAPI(video: WebCRTVideo): WorkerAPI {
+    const fakeState = {
+        setCallbacks: () => {},
+        video,
+        apple1: {
+            cpu: { toDebug: () => ({}) },
+            pia: { toDebug: () => ({}) },
+            bus: { read: () => 0, toDebug: () => ({}) },
+            clock: { toDebug: () => ({}) },
+        },
+        getDualEngine: () => null,
+    } as unknown as WorkerState;
+
+    return new WorkerAPI(fakeState);
+}
+
+describe('power-on-noise-screen — WorkerAPI', () => {
+    test('AC-4 (RENDER): late subscriber gets current frame', () => {
+        const video = new WebCRTVideo();
+        const api = makeWorkerAPI(video);
+
+        // Subscribe AFTER construction — like React mounting after the worker booted.
+        let received: VideoData | undefined;
+        api.onVideoUpdate((data) => {
+            received = data;
+        });
+
+        // The current power-on frame must be delivered immediately on subscribe.
+        expect(received).toBeDefined();
+        expect(received!.buffer.length).toBe(24);
+        expect(received!.buffer[0][1].length).toBe(40);
+    });
+});

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '4.46.0';
+export const APP_VERSION = '4.47.0';


### PR DESCRIPTION
## What & why

On a real Apple 1, video RAM powered up in an indeterminate state — there was no routine
to clear it — so the screen came up full of random "junk" characters until the operator
reset/cleared it. This is the iconic cold-start look in the original demo footage and other
emulators. Apple1JS used to show it, but it had disappeared (the screen came up blank).

Investigation found **two** issues, both fixed here:

1. **Lost cold-start frame (the regression).** Since the Comlink worker migration,
   `WorkerAPI.onVideoUpdate()` only *added* the React callback to its set — it never pushed
   the current frame. The power-on frame is emitted at worker construction (before React
   subscribes), so it was dropped, and the CRT showed its blank default until the next write.
2. **Fixed `@` fill instead of noise.** The cold-start buffer was a uniform `@` field rather
   than the authentic randomized junk.

## Changes

- `WebCRTVideo.ts` — power-on fills each cell with a random Apple-1 displayable glyph
  (`0x20`–`0x5F`), randomized per power-on (`powerOnNoiseBuffer()`), replacing the uniform `@`.
- `WorkerAPI.ts` — `onVideoUpdate` now delivers the current frame (`video.getState()`) to a
  new subscriber immediately, so a late subscriber (React mounting after the worker boots)
  actually sees the cold-start screen.
- Reset/clear path unchanged — TAB → reset cascade → `video.reset()` already clears to spaces.
- Version bumped 4.46.0 → 4.47.0 (feat ⇒ minor).

## Scope / parity

JS-only display change. The video buffer lives in `WebCRTVideo`; display writes reach it via
`PIA → DisplayLogic → CRTVideo` regardless of CPU engine, so **dual-engine parity is N/A**
(no CPU/core behavior changes).

## Testing

- Built via Spec-Driven Development (spec/plan/tasks/audit, local-only under `docs/specs/`).
- New tests: `WebCRTVideo-power-on-noise-screen` (AC-1/2/3/5) + `WorkerAPI-power-on-noise-screen`
  (AC-4). Existing "Cold State" unit test re-spec'd from uniform-`@` to noise-range.
- `yarn test:ci` green: lint + type-check + 715 tests pass (19 skipped = browser-only WASM parity).
- **Verified in-browser**: random noise on load, a *different* pattern on reload, and TAB
  clears the screen to the Woz Monitor reset prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Apple-1 CRT now displays power-on "junk" with random characters on startup, emulating authentic vintage hardware behavior.

* **Improvements**
  * Late subscribers to video updates now immediately receive the current frame state without waiting for the next update.

* **Tests**
  * Added comprehensive test coverage for power-on noise display behavior.

* **Chores**
  * Version bumped to 4.47.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stid/Apple1JS/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->