### PR TITLE
fix: unify CPU breakpoints across JS + WASM engines

### DIFF
--- a/src/apple1/WorkerAPI.ts
+++ b/src/apple1/WorkerAPI.ts
@@ -253,6 +253,19 @@ export class WorkerAPI implements IWorkerAPI {
             return;
         }
 
+        // Run-to-cursor is realized as a transient engine breakpoint. Without a
+        // dual engine (e.g. the non-worker inspector path, useDualEngine=false)
+        // there is nothing to set a breakpoint on, so resuming would silently run
+        // past the target. Bail with a warning instead of a misleading "running".
+        if (!dualEngine) {
+            loggingService.log(
+                'warn',
+                'RunToAddress',
+                `Cannot run to ${Formatters.address(targetAddress)} without a dual engine; ignoring.`,
+            );
+            return;
+        }
+
         // Store the run-to-cursor target and notify listeners.
         this.workerState.runToCursorTarget = targetAddress;
         this.runToCursorCallbacks.forEach((cb) => cb(this.workerState.runToCursorTarget));
@@ -262,7 +275,7 @@ export class WorkerAPI implements IWorkerAPI {
         // user breakpoint). This works for both engines, unlike the old JS-only
         // execution hook.
         if (!this.workerState.breakpoints.has(targetAddress)) {
-            dualEngine?.setBreakpoint(targetAddress);
+            dualEngine.setBreakpoint(targetAddress);
         }
 
         // Resume execution to run to the target.

--- a/src/apple1/WorkerAPI.ts
+++ b/src/apple1/WorkerAPI.ts
@@ -29,18 +29,47 @@ export class WorkerAPI implements IWorkerAPI {
     private runToCursorCallbacks = new Set<(target: number | null) => void>();
 
     constructor(private workerState: WorkerState) {
-        // Set up callbacks for WorkerState to use
-        this.workerState.setCallbacks({
-            onStatus: (status) => {
-                this.statusCallbacks.forEach((cb) => cb(status));
-            },
-            onBreakpoint: (address) => {
-                this.breakpointCallbacks.forEach((cb) => cb(address));
-            },
-        });
+        // Enforce breakpoints uniformly across engines: subscribe to the active
+        // engine's breakpoint-hit signal and route it to the pause/notify path.
+        // This works identically for the JS engine (CPU6502 execution hook) and
+        // the WASM engine (Rust-side check) — the worker no longer installs a
+        // JS-CPU-only hook, which is why WASM breakpoints never used to fire.
+        this.workerState.getDualEngine()?.onBreakpointHit?.((address) => this.handleBreakpointHit(address));
 
         // Set up internal event subscriptions (including logging handler)
         this.setupInternalSubscriptions();
+    }
+
+    /**
+     * Single, engine-agnostic breakpoint-hit handler. Invoked by the active CPU
+     * engine when execution halts on a breakpoint. Pauses the clock and notifies
+     * the UI; also resolves a transient run-to-cursor target.
+     */
+    private handleBreakpointHit(address: number): void {
+        // A deliberate single step bypasses breakpoints (stepping off one).
+        if (this.workerState.isStepping) {
+            return;
+        }
+
+        this.workerState.apple1.clock.pause();
+        this.workerState.isPaused = true;
+
+        // Run-to-cursor: if this is the transient target, clear it (unless it is
+        // also a real user breakpoint) and report completion rather than a hit.
+        const target = this.workerState.runToCursorTarget;
+        if (target !== null && address === target) {
+            this.workerState.runToCursorTarget = null;
+            if (!this.workerState.breakpoints.has(target)) {
+                this.workerState.getDualEngine()?.clearBreakpoint(target);
+            }
+            this.statusCallbacks.forEach((cb) => cb('paused'));
+            this.runToCursorCallbacks.forEach((cb) => cb(null));
+            return;
+        }
+
+        this.statusCallbacks.forEach((cb) => cb('paused'));
+        this.breakpointCallbacks.forEach((cb) => cb(address));
+        loggingService.log('info', 'Breakpoint', `Hit breakpoint at ${Formatters.address(address)}`);
     }
 
     /**
@@ -120,28 +149,38 @@ export class WorkerAPI implements IWorkerAPI {
     }
 
     step(): FilteredDebugData {
+        const { cpu, pia, bus, clock } = this.workerState.apple1;
+        const dualEngine = this.workerState.getDualEngine();
+
         // First pause the clock to prevent concurrent execution
-        this.workerState.apple1.clock.pause();
+        clock.pause();
         this.workerState.isPaused = true;
 
-        // Set stepping flag to bypass breakpoint check for this instruction
+        // Set stepping flag so the engine/handler bypass any breakpoint on the
+        // current PC (this is how the debugger steps *off* a breakpoint).
         this.workerState.isStepping = true;
 
-        // Execute one instruction
-        this.workerState.apple1.cpu.performSingleStep();
+        // Step the *active* engine (JS CPU only when there is no dual engine).
+        if (dualEngine) {
+            dualEngine.performSingleStep();
+        } else {
+            cpu.performSingleStep();
+        }
 
         // Clear stepping flag
         this.workerState.isStepping = false;
 
-        // Check if we hit a breakpoint after stepping (at the new PC)
-        if (this.workerState.breakpoints.has(this.workerState.apple1.cpu.PC)) {
-            this.breakpointCallbacks.forEach((cb) => cb(this.workerState.apple1.cpu.PC));
+        // Check if we landed on a breakpoint after stepping (at the new PC).
+        const pc = dualEngine?.getRegisters ? dualEngine.getRegisters().PC : cpu.PC;
+        if (this.workerState.breakpoints.has(pc)) {
+            this.breakpointCallbacks.forEach((cb) => cb(pc));
         }
 
-        // Return debug info, filtering out boolean and object values for backward compatibility
-        const { cpu, pia, bus, clock } = this.workerState.apple1;
+        // CPU state must come from the active engine (the JS CPU is dormant/stale
+        // under WASM); other components are engine-independent.
+        const cpuDebug = dualEngine?.toDebug ? dualEngine.toDebug() : cpu.toDebug();
         return {
-            cpu: this.filterDebugData(cpu.toDebug()),
+            cpu: this.filterDebugData(cpuDebug),
             pia: this.filterDebugData(pia.toDebug()),
             Bus: this.filterDebugData(bus.toDebug()),
             clock: this.filterDebugData(clock.toDebug()),
@@ -178,20 +217,21 @@ export class WorkerAPI implements IWorkerAPI {
 
     setBreakpoint(address: number): number[] {
         this.workerState.breakpoints.add(address);
-        this.workerState.updateBreakpointHook();
-
+        // Route to the active engine so the running engine actually enforces it
+        // (for WASM this populates the Rust breakpoint set).
+        this.workerState.getDualEngine()?.setBreakpoint(address);
         return Array.from(this.workerState.breakpoints);
     }
 
     clearBreakpoint(address: number): number[] {
         this.workerState.breakpoints.delete(address);
-        this.workerState.updateBreakpointHook();
+        this.workerState.getDualEngine()?.clearBreakpoint(address);
         return Array.from(this.workerState.breakpoints);
     }
 
     clearAllBreakpoints(): void {
         this.workerState.breakpoints.clear();
-        this.workerState.updateBreakpointHook();
+        this.workerState.getDualEngine()?.clearAllBreakpoints();
     }
 
     getBreakpoints(): number[] {
@@ -200,9 +240,11 @@ export class WorkerAPI implements IWorkerAPI {
 
     runToAddress(address: number): void {
         const targetAddress = address;
+        const dualEngine = this.workerState.getDualEngine();
 
-        // Don't run if we're already at the target address
-        if (this.workerState.apple1.cpu.PC === targetAddress) {
+        // Don't run if we're already at the target address (read the active engine).
+        const currentPC = dualEngine?.getRegisters ? dualEngine.getRegisters().PC : this.workerState.apple1.cpu.PC;
+        if (currentPC === targetAddress) {
             loggingService.log(
                 'info',
                 'RunToAddress',
@@ -211,57 +253,19 @@ export class WorkerAPI implements IWorkerAPI {
             return;
         }
 
-        // Store the run-to-cursor target
+        // Store the run-to-cursor target and notify listeners.
         this.workerState.runToCursorTarget = targetAddress;
-
-        // Notify callbacks about the run-to-cursor target
         this.runToCursorCallbacks.forEach((cb) => cb(this.workerState.runToCursorTarget));
 
-        // Set up a temporary execution hook for run-to-address
-        let runToAddressHit = false;
+        // Model run-to-cursor as a transient breakpoint on the active engine.
+        // handleBreakpointHit() clears it on arrival (unless it is also a real
+        // user breakpoint). This works for both engines, unlike the old JS-only
+        // execution hook.
+        if (!this.workerState.breakpoints.has(targetAddress)) {
+            dualEngine?.setBreakpoint(targetAddress);
+        }
 
-        this.workerState.apple1.cpu.setExecutionHook((pc: number) => {
-            // Skip breakpoint check if we're stepping
-            if (this.workerState.isStepping) {
-                return true;
-            }
-
-            // Check existing breakpoints first
-            if (!this.workerState.isPaused && this.workerState.breakpoints.has(pc)) {
-                // Hit a breakpoint - pause execution
-                this.workerState.apple1.clock.pause();
-                this.workerState.isPaused = true;
-                this.statusCallbacks.forEach((cb) => cb('paused'));
-                this.breakpointCallbacks.forEach((cb) => cb(pc));
-                loggingService.log('info', 'Breakpoint', `Hit breakpoint at ${Formatters.address(pc)}`);
-                return false; // Halt execution
-            }
-
-            // Check if we've reached the target address
-            if (pc === targetAddress && !runToAddressHit) {
-                runToAddressHit = true;
-                // Clear run-to-cursor target
-                this.workerState.runToCursorTarget = null;
-                // Pause execution
-                this.workerState.apple1.clock.pause();
-                this.workerState.isPaused = true;
-                // Restore normal breakpoint hook
-                this.workerState.updateBreakpointHook();
-                // Send notifications
-                this.statusCallbacks.forEach((cb) => cb('paused'));
-                this.runToCursorCallbacks.forEach((cb) => cb(null));
-                loggingService.log(
-                    'info',
-                    'RunToAddress',
-                    `Reached target address ${Formatters.address(targetAddress)}`,
-                );
-                return false; // Halt execution
-            }
-
-            return true; // Continue execution
-        });
-
-        // Resume execution to run to the target
+        // Resume execution to run to the target.
         if (this.workerState.isPaused) {
             this.workerState.apple1.clock.resume();
             this.workerState.isPaused = false;

--- a/src/apple1/WorkerState.ts
+++ b/src/apple1/WorkerState.ts
@@ -3,7 +3,6 @@ import WebWorkerKeyboard from './WebKeyboard';
 import WebCRTVideo from './WebCRTVideo';
 import type { IWorkerState } from './types/worker-api';
 import { loggingService } from '../services/LoggingService';
-import { Formatters } from '../utils/formatters';
 import type { DualEngine } from '../core/cpu-engines';
 import type { EngineStatusData, EngineComparisonData, EngineMetricsData } from './types/worker-messages';
 
@@ -30,10 +29,6 @@ export class WorkerState implements IWorkerState {
     public debuggerActive: boolean;
     public debugUpdateInterval: number | null;
 
-    // Callbacks for events
-    private statusCallback?: (status: 'running' | 'paused') => void;
-    private breakpointCallback?: (address: number) => void;
-
     constructor() {
         // Initialize video and keyboard
         this.video = new WebCRTVideo();
@@ -57,9 +52,6 @@ export class WorkerState implements IWorkerState {
 
         // Set up video subscription
         this.setupVideoSubscription();
-
-        // Initialize breakpoint hook
-        this.updateBreakpointHook();
     }
 
     /**
@@ -68,52 +60,6 @@ export class WorkerState implements IWorkerState {
     private setupVideoSubscription(): void {
         // Video updates are handled directly in WorkerAPI
         // This is kept for compatibility
-    }
-
-    /**
-     * Update the CPU execution hook for breakpoint checking
-     */
-    public updateBreakpointHook(): void {
-        if (this.breakpoints.size === 0) {
-            // No breakpoints - remove hook for performance
-            this.apple1.cpu.setExecutionHook(undefined);
-        } else {
-            // Install hook to check breakpoints before each instruction
-            this.apple1.cpu.setExecutionHook((pc: number) => {
-                // Skip breakpoint check if we're stepping (to allow stepping over breakpoints)
-                if (this.isStepping) {
-                    return true;
-                }
-
-                // Only check breakpoints when running (not already paused)
-                if (!this.isPaused && this.breakpoints.has(pc)) {
-                    // Hit a breakpoint - pause execution
-                    this.apple1.clock.pause();
-                    this.isPaused = true;
-                    // Use callbacks if available
-                    if (this.statusCallback) {
-                        this.statusCallback('paused');
-                    }
-                    if (this.breakpointCallback) {
-                        this.breakpointCallback(pc);
-                    }
-                    loggingService.log('info', 'Breakpoint', `Hit breakpoint at ${Formatters.address(pc)}`);
-                    return false; // Halt execution
-                }
-                return true; // Continue execution
-            });
-        }
-    }
-
-    /**
-     * Set callbacks for events
-     */
-    public setCallbacks(callbacks: {
-        onStatus?: (status: 'running' | 'paused') => void;
-        onBreakpoint?: (address: number) => void;
-    }): void {
-        if (callbacks.onStatus) this.statusCallback = callbacks.onStatus;
-        if (callbacks.onBreakpoint) this.breakpointCallback = callbacks.onBreakpoint;
     }
 
     /**

--- a/src/apple1/__tests__/WorkerAPI-breakpoint-engine-routing.vitest.test.ts
+++ b/src/apple1/__tests__/WorkerAPI-breakpoint-engine-routing.vitest.test.ts
@@ -1,0 +1,133 @@
+/**
+ * WorkerAPI breakpoint engine-routing tests
+ *
+ * Regression: breakpoints set through the worker never reached the active CPU
+ * engine, so the WASM engine (the default) never enforced them — its Rust
+ * HashSet stayed empty. These tests pin two contracts:
+ *
+ *  1. set/clear/clearAll route to the active (dual) engine, so the running
+ *     engine (incl. the Rust HashSet) is actually populated.
+ *  2. an engine-reported hit drives the unified pause/notify path
+ *     (clock.pause + isPaused + status('paused') + breakpoint(pc)).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { WorkerAPI } from '../WorkerAPI';
+import type { WorkerState } from '../WorkerState';
+
+interface EngineCall {
+    op: 'set' | 'clear' | 'clearAll';
+    address?: number;
+}
+
+/** A fake dual engine that records breakpoint routing and captures the hit listener. */
+function makeFakeEngine() {
+    const calls: EngineCall[] = [];
+    let hitListener: ((address: number) => void) | undefined;
+    return {
+        calls,
+        /** Simulate the engine (e.g. WASM/Rust) reporting a breakpoint hit. */
+        fireHit(address: number) {
+            hitListener?.(address);
+        },
+        engine: {
+            setBreakpoint: (address: number) => calls.push({ op: 'set', address }),
+            clearBreakpoint: (address: number) => calls.push({ op: 'clear', address }),
+            clearAllBreakpoints: () => calls.push({ op: 'clearAll' }),
+            getRegisters: () => ({ PC: 0x1234 }),
+            onBreakpointHit: (cb: (address: number) => void) => {
+                hitListener = cb;
+                return () => {
+                    hitListener = undefined;
+                };
+            },
+            toDebug: () => ({}),
+        },
+    };
+}
+
+function makeWorkerAPI(fakeEngine: ReturnType<typeof makeFakeEngine>) {
+    const pauseCalls: number[] = [];
+    const state = {
+        setCallbacks: () => {},
+        video: undefined,
+        breakpoints: new Set<number>(),
+        runToCursorTarget: null as number | null,
+        isPaused: false,
+        isStepping: false,
+        apple1: {
+            cpu: { PC: 0x0000, toDebug: () => ({}) },
+            clock: {
+                pause: () => pauseCalls.push(1),
+                resume: () => {},
+            },
+        },
+        getDualEngine: () => fakeEngine.engine,
+    };
+    const api = new WorkerAPI(state as unknown as WorkerState);
+    return { api, state, pauseCalls };
+}
+
+describe('WorkerAPI breakpoint routing to the active engine', () => {
+    it('setBreakpoint routes to the active engine (populates the running engine)', () => {
+        const fake = makeFakeEngine();
+        const { api } = makeWorkerAPI(fake);
+
+        api.setBreakpoint(0x1234);
+
+        expect(fake.calls).toContainEqual({ op: 'set', address: 0x1234 });
+    });
+
+    it('clearBreakpoint and clearAllBreakpoints route to the active engine', () => {
+        const fake = makeFakeEngine();
+        const { api } = makeWorkerAPI(fake);
+
+        api.setBreakpoint(0x10);
+        api.clearBreakpoint(0x10);
+        api.clearAllBreakpoints();
+
+        expect(fake.calls).toEqual([{ op: 'set', address: 0x10 }, { op: 'clear', address: 0x10 }, { op: 'clearAll' }]);
+    });
+
+    it('still tracks breakpoints in worker state and returns the list', () => {
+        const fake = makeFakeEngine();
+        const { api, state } = makeWorkerAPI(fake);
+
+        const after = api.setBreakpoint(0x20);
+        expect(after).toEqual([0x20]);
+        expect(state.breakpoints.has(0x20)).toBe(true);
+    });
+});
+
+describe('WorkerAPI unified breakpoint-hit notification', () => {
+    it('an engine-reported hit pauses the clock and notifies status + breakpoint callbacks', () => {
+        const fake = makeFakeEngine();
+        const { api, state, pauseCalls } = makeWorkerAPI(fake);
+
+        const statuses: string[] = [];
+        const hits: number[] = [];
+        api.onEmulationStatus((s) => statuses.push(s));
+        api.onBreakpointHit((addr) => hits.push(addr));
+
+        fake.fireHit(0x300);
+
+        expect(pauseCalls.length).toBe(1);
+        expect(state.isPaused).toBe(true);
+        expect(statuses).toContain('paused');
+        expect(hits).toEqual([0x300]);
+    });
+
+    it('ignores a hit while single-stepping (stepping bypasses breakpoints)', () => {
+        const fake = makeFakeEngine();
+        const { api, state, pauseCalls } = makeWorkerAPI(fake);
+        state.isStepping = true;
+
+        const hits: number[] = [];
+        api.onBreakpointHit((addr) => hits.push(addr));
+
+        fake.fireHit(0x300);
+
+        expect(pauseCalls.length).toBe(0);
+        expect(hits).toEqual([]);
+    });
+});

--- a/src/apple1/__tests__/WorkerAPI-run-to-address.vitest.test.ts
+++ b/src/apple1/__tests__/WorkerAPI-run-to-address.vitest.test.ts
@@ -110,4 +110,27 @@ describe('WorkerAPI.runToAddress', () => {
         expect(fake.calls).toEqual([]);
         expect(resumeCalls.length).toBe(0);
     });
+
+    it('does not resume when there is no dual engine (avoids running past the target)', () => {
+        const resumeCalls: number[] = [];
+        const state = {
+            setCallbacks: () => {},
+            video: undefined,
+            breakpoints: new Set<number>(),
+            runToCursorTarget: null as number | null,
+            isPaused: true,
+            isStepping: false,
+            apple1: {
+                cpu: { PC: 0x0000, toDebug: () => ({}) },
+                clock: { pause: () => {}, resume: () => resumeCalls.push(1) },
+            },
+            getDualEngine: () => null,
+        };
+        const api = new WorkerAPI(state as unknown as WorkerState);
+
+        api.runToAddress(0xff00);
+
+        expect(resumeCalls.length).toBe(0);
+        expect(state.runToCursorTarget).toBeNull();
+    });
 });

--- a/src/apple1/__tests__/WorkerAPI-run-to-address.vitest.test.ts
+++ b/src/apple1/__tests__/WorkerAPI-run-to-address.vitest.test.ts
@@ -1,0 +1,113 @@
+/**
+ * WorkerAPI run-to-cursor tests
+ *
+ * Run-to-cursor previously installed an execution hook on apple1.cpu (the JS
+ * CPU only), so it never worked when the WASM engine was active. The unified
+ * implementation models it as a *transient* breakpoint on the active engine:
+ * set the target as a breakpoint, resume, and clear it once reached.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { WorkerAPI } from '../WorkerAPI';
+import type { WorkerState } from '../WorkerState';
+
+interface EngineCall {
+    op: 'set' | 'clear' | 'clearAll';
+    address?: number;
+}
+
+function makeFakeEngine(currentPC: number) {
+    const calls: EngineCall[] = [];
+    let hitListener: ((address: number) => void) | undefined;
+    return {
+        calls,
+        fireHit(address: number) {
+            hitListener?.(address);
+        },
+        engine: {
+            setBreakpoint: (address: number) => calls.push({ op: 'set', address }),
+            clearBreakpoint: (address: number) => calls.push({ op: 'clear', address }),
+            clearAllBreakpoints: () => calls.push({ op: 'clearAll' }),
+            getRegisters: () => ({ PC: currentPC }),
+            onBreakpointHit: (cb: (address: number) => void) => {
+                hitListener = cb;
+                return () => {
+                    hitListener = undefined;
+                };
+            },
+            toDebug: () => ({}),
+        },
+    };
+}
+
+function makeWorkerAPI(fake: ReturnType<typeof makeFakeEngine>, isPaused = true) {
+    const resumeCalls: number[] = [];
+    const state = {
+        setCallbacks: () => {},
+        video: undefined,
+        breakpoints: new Set<number>(),
+        runToCursorTarget: null as number | null,
+        isPaused,
+        isStepping: false,
+        apple1: {
+            cpu: { PC: 0x0000, toDebug: () => ({}) },
+            clock: {
+                pause: () => {},
+                resume: () => resumeCalls.push(1),
+            },
+        },
+        getDualEngine: () => fake.engine,
+    };
+    const api = new WorkerAPI(state as unknown as WorkerState);
+    return { api, state, resumeCalls };
+}
+
+describe('WorkerAPI.runToAddress', () => {
+    it('sets a transient breakpoint on the active engine and resumes', () => {
+        const fake = makeFakeEngine(0x0000);
+        const { api, state, resumeCalls } = makeWorkerAPI(fake);
+
+        api.runToAddress(0xff00);
+
+        expect(fake.calls).toContainEqual({ op: 'set', address: 0xff00 });
+        expect(state.runToCursorTarget).toBe(0xff00);
+        expect(resumeCalls.length).toBe(1);
+    });
+
+    it('clears the transient breakpoint and reports completion when the target is reached', () => {
+        const fake = makeFakeEngine(0x0000);
+        const { api, state } = makeWorkerAPI(fake);
+
+        const targets: Array<number | null> = [];
+        api.onRunToCursorTarget((t) => targets.push(t));
+
+        api.runToAddress(0xff00);
+        fake.fireHit(0xff00);
+
+        expect(fake.calls).toContainEqual({ op: 'clear', address: 0xff00 });
+        expect(state.runToCursorTarget).toBeNull();
+        expect(targets).toEqual([0xff00, null]);
+    });
+
+    it('does not clear a target that is also a real user breakpoint', () => {
+        const fake = makeFakeEngine(0x0000);
+        const { api, state } = makeWorkerAPI(fake);
+        state.breakpoints.add(0xff00); // user breakpoint at the same address
+
+        api.runToAddress(0xff00);
+        fake.fireHit(0xff00);
+
+        // The user breakpoint must survive run-to-cursor completion.
+        expect(fake.calls).not.toContainEqual({ op: 'clear', address: 0xff00 });
+    });
+
+    it('does nothing when already at the target address', () => {
+        const fake = makeFakeEngine(0xff00); // active engine PC already at target
+        const { api, resumeCalls } = makeWorkerAPI(fake);
+
+        api.runToAddress(0xff00);
+
+        expect(fake.calls).toEqual([]);
+        expect(resumeCalls.length).toBe(0);
+    });
+});

--- a/src/apple1/index.ts
+++ b/src/apple1/index.ts
@@ -22,11 +22,15 @@ import anniversary from './progs/anniversary';
 import basic from './progs/basic';
 import wozMonitor from './progs/woz_monitor';
 import { IoComponent, BusSpaceType } from '@/core/types';
-import { 
-    ROM_START, ROM_END, 
-    RAM_BANK1_START, RAM_BANK1_END,
-    RAM_BANK2_START, RAM_BANK2_END,
-    PIA_START, PIA_END 
+import {
+    ROM_START,
+    ROM_END,
+    RAM_BANK1_START,
+    RAM_BANK1_END,
+    RAM_BANK2_START,
+    RAM_BANK2_END,
+    PIA_START,
+    PIA_END,
 } from '../core/constants/memory';
 import { CPU_SPEED_MHZ, CPU_STEP_INTERVAL_MS } from './constants/system';
 
@@ -49,7 +53,7 @@ interface Apple1State extends StateBase {
     /** System configuration */
     cpuSpeedMHz: number;
     stepIntervalMs: number;
-    
+
     /** Component states - using the new stateful component pattern */
     cpu: ReturnType<CPU6502['saveState']>;
     clock: ReturnType<Clock['saveState']>;
@@ -57,10 +61,10 @@ interface Apple1State extends StateBase {
     ramBank1: ReturnType<RAM['saveState']>;
     ramBank2: ReturnType<RAM['saveState']>;
     pia: ReturnType<PIA6820['saveState']>;
-    
+
     /** Video state (if available) */
     video?: VideoState;
-    
+
     /** System identification */
     systemId: string;
 }
@@ -78,11 +82,11 @@ class Apple1 implements IInspectableComponent, IVersionedStatefulComponent<Apple
             cpu: this.cpu.saveState(),
             pia: this.pia.saveState() as PIAState,
         };
-        
+
         if (typeof this.video.getState === 'function') {
             state.video = this.video.getState();
         }
-        
+
         return state;
     }
 
@@ -104,7 +108,7 @@ class Apple1 implements IInspectableComponent, IVersionedStatefulComponent<Apple
                 crb: state.pia.crb,
                 controlLines: state.pia.controlLines,
                 pb7InputState: false, // Default for old states
-                componentId: 'pia6820'
+                componentId: 'pia6820',
             };
             this.pia.loadState(convertedPIAState);
         }
@@ -131,7 +135,7 @@ class Apple1 implements IInspectableComponent, IVersionedStatefulComponent<Apple
                 version: '1.0', // Mark as old version to trigger migration
                 data: saved.state.data,
                 size: saved.state.data.length,
-                componentId: saved.id
+                componentId: saved.id,
             };
 
             if (saved.id === this.ramBank1.id) {
@@ -225,13 +229,17 @@ class Apple1 implements IInspectableComponent, IVersionedStatefulComponent<Apple
     busMapping: Array<BusSpaceType>;
     bus: Bus;
     cpu: CPU6502;
-    cpuEngine?: ICPUEngine;  // Optional dual-engine CPU
+    cpuEngine?: ICPUEngine; // Optional dual-engine CPU
     clock: Clock;
     useDualEngine: boolean;
 
-    constructor({ video, keyboard, useDualEngine = false }: { 
-        video: IoComponent<VideoState>; 
-        keyboard: IoComponent; 
+    constructor({
+        video,
+        keyboard,
+        useDualEngine = false,
+    }: {
+        video: IoComponent<VideoState>;
+        keyboard: IoComponent;
         useDualEngine?: boolean;
     }) {
         this.useDualEngine = useDualEngine;
@@ -286,19 +294,17 @@ class Apple1 implements IInspectableComponent, IVersionedStatefulComponent<Apple
         // Bound CPU to related Address Spaces
         this.bus = new Bus(this.busMapping);
         this.bus.name = 'System Bus';
-        
+
         // Create CPU - use DualEngine if enabled
         if (this.useDualEngine) {
-            this.cpuEngine = new DualEngine(this.bus, 'WASM'); // Prefer WASM; DualEngine falls back to JS when unavailable
-            // Get the internal CPU from the DualEngine for compatibility
-            // This allows WorkerState to set execution hooks for breakpoints
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            this.cpu = (this.cpuEngine as any).getInternalCPU();
-            
-            // DON'T override the CPU methods - this causes infinite recursion
-            // The Clock subscribes to cpuEngine directly, not cpu
-            // The cpu is only used for setExecutionHook for breakpoints
-            
+            const dualEngine = new DualEngine(this.bus, 'WASM'); // Prefer WASM; DualEngine falls back to JS when unavailable
+            this.cpuEngine = dualEngine;
+            // Hold the JS engine's CPU6502 as this.cpu for state save/load and
+            // inspection — it is kept synchronized with the active engine.
+            // Breakpoints are now enforced inside the engines, not via a hook here.
+            this.cpu = dualEngine.getInternalCPU();
+
+            // The Clock subscribes to cpuEngine directly, not this.cpu.
             this.cpu.name = 'Dual-Engine CPU (JS/WASM)';
             loggingService.info('Apple1', 'Using DualEngine CPU with runtime switching capability');
         } else {
@@ -385,7 +391,7 @@ class Apple1 implements IInspectableComponent, IVersionedStatefulComponent<Apple
                 loggingService.error('Apple1', `Failed to initialize CPU engine: ${error}`);
             }
         }
-        
+
         return this.clock.startLoop();
     }
 
@@ -398,7 +404,7 @@ class Apple1 implements IInspectableComponent, IVersionedStatefulComponent<Apple
      */
     saveState(options?: StateOptions): Apple1State {
         const opts = { includeDebugInfo: false, ...options };
-        
+
         const state: Apple1State = {
             version: Apple1.STATE_VERSION,
             // System configuration
@@ -426,7 +432,7 @@ class Apple1 implements IInspectableComponent, IVersionedStatefulComponent<Apple
                     timestamp: Date.now(),
                     componentId: 'Apple1',
                     systemType: 'Apple 1 Computer',
-                }
+                },
             });
         }
 
@@ -438,15 +444,11 @@ class Apple1 implements IInspectableComponent, IVersionedStatefulComponent<Apple
      */
     loadState(state: Apple1State, options?: StateOptions): void {
         const opts = { validate: true, migrate: true, ...options };
-        
+
         if (opts.validate) {
             const validation = this.validateState(state);
             if (!validation.valid) {
-                throw new StateError(
-                    `Invalid Apple1 state: ${validation.errors.join(', ')}`,
-                    'Apple1',
-                    'load'
-                );
+                throw new StateError(`Invalid Apple1 state: ${validation.errors.join(', ')}`, 'Apple1', 'load');
             }
         }
 
@@ -591,11 +593,7 @@ class Apple1 implements IInspectableComponent, IVersionedStatefulComponent<Apple
                 return this.migrateFromV1(state);
 
             default:
-                throw new StateError(
-                    `Unsupported Apple1 state version: ${fromVersion}`,
-                    'Apple1',
-                    'migrate'
-                );
+                throw new StateError(`Unsupported Apple1 state version: ${fromVersion}`, 'Apple1', 'migrate');
         }
     }
 
@@ -605,7 +603,7 @@ class Apple1 implements IInspectableComponent, IVersionedStatefulComponent<Apple
     private migrateFromV1(oldState: Record<string, unknown>): Apple1State {
         // Extract old state components
         const emulatorState = oldState as unknown as EmulatorState;
-        
+
         // Create new state format
         const newState: Apple1State = {
             version: Apple1.STATE_VERSION,
@@ -629,14 +627,14 @@ class Apple1 implements IInspectableComponent, IVersionedStatefulComponent<Apple
                         version: '1.0',
                         data: ramState.state.data,
                         size: ramState.state.data.length,
-                        componentId: 'ram1'
+                        componentId: 'ram1',
                     } as ReturnType<RAM['saveState']>;
                 } else if (ramState.id === 'ram2') {
                     newState.ramBank2 = {
                         version: '1.0',
                         data: ramState.state.data,
                         size: ramState.state.data.length,
-                        componentId: 'ram2'
+                        componentId: 'ram2',
                     } as ReturnType<RAM['saveState']>;
                 }
             });
@@ -649,7 +647,7 @@ class Apple1 implements IInspectableComponent, IVersionedStatefulComponent<Apple
                 version: '2.0',
                 ...emulatorState.pia,
                 pb7InputState: false,
-                componentId: 'pia6820'
+                componentId: 'pia6820',
             } as ReturnType<PIA6820['saveState']>;
         }
 

--- a/src/core/cpu-engines/DualEngine.ts
+++ b/src/core/cpu-engines/DualEngine.ts
@@ -14,6 +14,7 @@ import type {
     EngineComparison,
 } from '../cpu-interface/ICPUEngine';
 import type { CPU6502State } from '../cpu6502/types';
+import type CPU6502 from '../cpu6502/core';
 import type Bus from '../Bus';
 import { JSEngine } from './JSEngine';
 import { WasmEngine } from './WasmEngine';
@@ -230,6 +231,17 @@ export class DualEngine implements ICPUEngine {
 
     hasBreakpoint(address: number): boolean {
         return this.activeEngine.hasBreakpoint(address);
+    }
+
+    onBreakpointHit(callback: (address: number) => void): () => void {
+        // Subscribe on both engines so the listener keeps working across an
+        // engine switch. Each engine only emits while it is the one executing.
+        const unsubs: Array<() => void> = [];
+        const jsUnsub = this.jsEngine.onBreakpointHit?.(callback);
+        if (jsUnsub) unsubs.push(jsUnsub);
+        const wasmUnsub = this.wasmEngine?.onBreakpointHit?.(callback);
+        if (wasmUnsub) unsubs.push(wasmUnsub);
+        return () => unsubs.forEach((unsub) => unsub());
     }
 
     // ============ Performance & Metrics ============
@@ -517,14 +529,11 @@ export class DualEngine implements ICPUEngine {
     }
 
     /**
-     * Get the internal JS CPU for compatibility with execution hooks
-     * This is needed for breakpoint functionality in WorkerState
+     * The JS engine's underlying CPU6502. Apple1 holds this as its `this.cpu`
+     * for state save/load and inspection (the JS CPU is kept synchronized with
+     * the active engine). Typed accessor — no `any` cast required.
      */
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    public getInternalCPU(): any {
-        // Access the private cpu property of JSEngine
-        // This is a workaround for breakpoint support
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return (this.jsEngine as any).cpu;
+    getInternalCPU(): CPU6502 {
+        return this.jsEngine.getInternalCPU();
     }
 }

--- a/src/core/cpu-engines/JSEngine.ts
+++ b/src/core/cpu-engines/JSEngine.ts
@@ -27,6 +27,10 @@ export class JSEngine implements ICPUEngine {
 
     private cpu: CPU6502;
     private breakpoints = new Set<number>();
+    private breakpointListeners = new Set<(address: number) => void>();
+    // Set while performing a deliberate single step so the breakpoint on the
+    // current PC is ignored — this is how the debugger steps *off* a breakpoint.
+    private isSingleStepping = false;
     private metrics: EngineMetrics;
     private metricsStartTime: number;
     private lastMetricsUpdate: number;
@@ -69,13 +73,12 @@ export class JSEngine implements ICPUEngine {
     performSingleStep(): number {
         const startTime = Date.now();
 
-        // Check for breakpoints
-        if (this.breakpoints.has(this.cpu.PC)) {
-            // In a real implementation, we'd handle this differently
-            console.log(`Breakpoint hit at ${this.cpu.PC.toString(16)}`);
-        }
-
+        // A deliberate single step always advances, even when sitting on a
+        // breakpoint, so the debugger can step off it. The execution hook
+        // consults this flag.
+        this.isSingleStepping = true;
         const cycles = this.cpu.performSingleStep();
+        this.isSingleStepping = false;
 
         // Update metrics
         const duration = Date.now() - startTime;
@@ -192,14 +195,17 @@ export class JSEngine implements ICPUEngine {
 
     setBreakpoint(address: number): void {
         this.breakpoints.add(address);
+        this.updateExecutionHook();
     }
 
     clearBreakpoint(address: number): void {
         this.breakpoints.delete(address);
+        this.updateExecutionHook();
     }
 
     clearAllBreakpoints(): void {
         this.breakpoints.clear();
+        this.updateExecutionHook();
     }
 
     getBreakpoints(): number[] {
@@ -208,6 +214,43 @@ export class JSEngine implements ICPUEngine {
 
     hasBreakpoint(address: number): boolean {
         return this.breakpoints.has(address);
+    }
+
+    onBreakpointHit(callback: (address: number) => void): () => void {
+        this.breakpointListeners.add(callback);
+        return () => {
+            this.breakpointListeners.delete(callback);
+        };
+    }
+
+    /**
+     * The underlying CPU6502 instance. Apple1 uses this as its `this.cpu` for
+     * state save/load and inspection under the dual engine (the JS engine's CPU
+     * is the one kept in sync). Typed accessor — avoids an `any` cast.
+     */
+    getInternalCPU(): CPU6502 {
+        return this.cpu;
+    }
+
+    /**
+     * Install (or remove) the CPU6502 execution hook that enforces breakpoints.
+     * The hook is only present while breakpoints exist, so the no-breakpoint hot
+     * path keeps its per-instruction overhead at zero. When the PC reaches a
+     * breakpoint (and we're not single-stepping), it notifies listeners and
+     * returns false, which halts CPU6502 execution before that instruction runs.
+     */
+    private updateExecutionHook(): void {
+        if (this.breakpoints.size === 0) {
+            this.cpu.setExecutionHook(undefined);
+            return;
+        }
+        this.cpu.setExecutionHook((pc: number): boolean => {
+            if (!this.isSingleStepping && this.breakpoints.has(pc)) {
+                this.breakpointListeners.forEach((listener) => listener(pc));
+                return false; // Halt before executing the instruction at the breakpoint
+            }
+            return true;
+        });
     }
 
     // ============ Performance & Metrics ============
@@ -342,6 +385,8 @@ export class JSEngine implements ICPUEngine {
     cleanup(): void {
         // Clean up any resources
         this.breakpoints.clear();
+        this.breakpointListeners.clear();
+        this.updateExecutionHook();
         this.resetMetrics();
     }
 }

--- a/src/core/cpu-engines/JSEngine.ts
+++ b/src/core/cpu-engines/JSEngine.ts
@@ -9,6 +9,7 @@ import type { ICPUEngine, EngineType, CPURegisters, EngineMetrics } from '../cpu
 import type { CPU6502State } from '../cpu6502/types';
 import type Bus from '../Bus';
 import CPU6502 from '../cpu6502/core';
+import { loggingService } from '../../services/LoggingService';
 
 /**
  * JavaScript implementation of the CPU engine
@@ -75,10 +76,15 @@ export class JSEngine implements ICPUEngine {
 
         // A deliberate single step always advances, even when sitting on a
         // breakpoint, so the debugger can step off it. The execution hook
-        // consults this flag.
+        // consults this flag. Reset it in `finally` so a throw can't leave it
+        // stuck `true` (which would silently disable all later breakpoints).
+        let cycles: number;
         this.isSingleStepping = true;
-        const cycles = this.cpu.performSingleStep();
-        this.isSingleStepping = false;
+        try {
+            cycles = this.cpu.performSingleStep();
+        } finally {
+            this.isSingleStepping = false;
+        }
 
         // Update metrics
         const duration = Date.now() - startTime;
@@ -246,7 +252,15 @@ export class JSEngine implements ICPUEngine {
         }
         this.cpu.setExecutionHook((pc: number): boolean => {
             if (!this.isSingleStepping && this.breakpoints.has(pc)) {
-                this.breakpointListeners.forEach((listener) => listener(pc));
+                // Isolate listener failures: a throwing listener must not escape
+                // the execution hook and break the run loop / pause handling.
+                this.breakpointListeners.forEach((listener) => {
+                    try {
+                        listener(pc);
+                    } catch (error) {
+                        loggingService.error('JSEngine', `Breakpoint listener threw: ${error}`);
+                    }
+                });
                 return false; // Halt before executing the instruction at the breakpoint
             }
             return true;

--- a/src/core/cpu-engines/WasmEngine.ts
+++ b/src/core/cpu-engines/WasmEngine.ts
@@ -268,14 +268,19 @@ export class WasmEngine implements ICPUEngine {
             this.wasmSystem.clear_breakpoint(currentPC);
         }
 
-        // Execute one instruction in WASM (breakpoint checking happens in Rust!)
-        const cycles = this.wasmSystem.step();
-
-        if (liftBreakpoint) {
-            this.wasmSystem.set_breakpoint(currentPC);
+        // Execute one instruction in WASM (breakpoint checking happens in Rust!).
+        // Restore the lifted breakpoint in `finally` so a throw can't leave it
+        // permanently cleared.
+        let cycles: number;
+        try {
+            cycles = this.wasmSystem.step();
+        } finally {
+            if (liftBreakpoint) {
+                this.wasmSystem.set_breakpoint(currentPC);
+            }
+            // A deliberate step never pauses on a breakpoint; clear any stale flag.
+            this.wasmSystem.clear_breakpoint_hit();
         }
-        // A deliberate step never pauses on a breakpoint; clear any stale flag.
-        this.wasmSystem.clear_breakpoint_hit();
 
         // CRITICAL: If WASM returns 0 cycles, something went wrong
         if (cycles === 0) {
@@ -315,7 +320,15 @@ export class WasmEngine implements ICPUEngine {
         const breakpointAddr = this.wasmSystem.get_breakpoint_hit();
         if (breakpointAddr >= 0) {
             this.wasmSystem.clear_breakpoint_hit();
-            this.breakpointListeners.forEach((listener) => listener(breakpointAddr));
+            // Isolate listener failures so one throwing callback can't interrupt
+            // dispatch or bubble into engine control flow.
+            this.breakpointListeners.forEach((listener) => {
+                try {
+                    listener(breakpointAddr);
+                } catch (error) {
+                    loggingService.error('WasmEngine', `Breakpoint listener threw: ${error}`);
+                }
+            });
         }
 
         // Note: I/O happens automatically via memory bridge - no sync needed

--- a/src/core/cpu-engines/WasmEngine.ts
+++ b/src/core/cpu-engines/WasmEngine.ts
@@ -36,6 +36,7 @@ export class WasmEngine implements ICPUEngine {
     private wasmSystem: WasmSystem | null = null;
     private bus: Bus; // Keep for I/O synchronization
     private breakpoints = new Set<number>();
+    private breakpointListeners = new Set<(address: number) => void>();
     private metrics: EngineMetrics;
     private metricsStartTime: number;
     private lastMetricsUpdate: number;
@@ -257,23 +258,27 @@ export class WasmEngine implements ICPUEngine {
 
         const startTime = Date.now();
 
+        // A deliberate single step must advance even when the PC sits on a
+        // breakpoint, so the debugger can step *off* it. Rust checks the
+        // breakpoint before executing and would return 0 forever otherwise, so
+        // lift any breakpoint on the current PC across this one step.
+        const currentPC = this.wasmSystem.get_cpu_state().pc;
+        const liftBreakpoint = this.breakpoints.has(currentPC);
+        if (liftBreakpoint) {
+            this.wasmSystem.clear_breakpoint(currentPC);
+        }
+
         // Execute one instruction in WASM (breakpoint checking happens in Rust!)
         const cycles = this.wasmSystem.step();
 
-        // Check if a breakpoint was hit (WASM returns 0 cycles on breakpoint)
-        const breakpointAddr = this.wasmSystem.get_breakpoint_hit();
-        if (breakpointAddr >= 0) {
-            loggingService.info(
-                'WasmEngine',
-                `Breakpoint hit at $${breakpointAddr.toString(16).toUpperCase().padStart(4, '0')}`,
-            );
-            // Don't clear the flag - let the caller handle it
-            // This signals to DualEngine/WorkerState that execution should pause
-            return 0; // Signal breakpoint hit
+        if (liftBreakpoint) {
+            this.wasmSystem.set_breakpoint(currentPC);
         }
+        // A deliberate step never pauses on a breakpoint; clear any stale flag.
+        this.wasmSystem.clear_breakpoint_hit();
 
-        // CRITICAL: If WASM returns 0 cycles without breakpoint, something went wrong
-        if (cycles === 0 && breakpointAddr < 0) {
+        // CRITICAL: If WASM returns 0 cycles, something went wrong
+        if (cycles === 0) {
             const cpuState = this.wasmSystem.get_cpu_state();
             loggingService.error(
                 'WasmEngine',
@@ -303,13 +308,14 @@ export class WasmEngine implements ICPUEngine {
         const executedCycles = this.wasmSystem.run_cycles(cycles);
         this.hostExecMs += performance.now() - startTime;
 
-        // Check if a breakpoint was hit during bulk execution
+        // Check if a breakpoint was hit during bulk execution. Rust halts before
+        // executing the instruction at the breakpoint, leaving the PC parked on
+        // it. Emit the unified hit signal so the worker pauses + notifies the UI,
+        // then clear the flag so the next run starts clean.
         const breakpointAddr = this.wasmSystem.get_breakpoint_hit();
         if (breakpointAddr >= 0) {
-            loggingService.info(
-                'WasmEngine',
-                `Breakpoint hit during bulk execution at $${breakpointAddr.toString(16).toUpperCase().padStart(4, '0')}`,
-            );
+            this.wasmSystem.clear_breakpoint_hit();
+            this.breakpointListeners.forEach((listener) => listener(breakpointAddr));
         }
 
         // Note: I/O happens automatically via memory bridge - no sync needed
@@ -604,24 +610,11 @@ export class WasmEngine implements ICPUEngine {
         return this.breakpoints.has(address);
     }
 
-    /**
-     * Check if a breakpoint was hit during the last step
-     * Returns the address of the breakpoint, or -1 if none
-     */
-    getBreakpointHit(): number {
-        if (!this.wasmSystem) {
-            return -1;
-        }
-        return this.wasmSystem.get_breakpoint_hit();
-    }
-
-    /**
-     * Clear the breakpoint hit flag after handling it
-     */
-    clearBreakpointHit(): void {
-        if (this.wasmSystem) {
-            this.wasmSystem.clear_breakpoint_hit();
-        }
+    onBreakpointHit(callback: (address: number) => void): () => void {
+        this.breakpointListeners.add(callback);
+        return () => {
+            this.breakpointListeners.delete(callback);
+        };
     }
 
     // ============ Performance & Metrics ============
@@ -906,6 +899,7 @@ export class WasmEngine implements ICPUEngine {
 
         // Clean up other resources
         this.breakpoints.clear();
+        this.breakpointListeners.clear();
         this.resetMetrics();
         this._isReady = false;
         this.initPromise = null;

--- a/src/core/cpu-engines/__tests__/DualEngine-breakpoint-routing.vitest.test.ts
+++ b/src/core/cpu-engines/__tests__/DualEngine-breakpoint-routing.vitest.test.ts
@@ -1,0 +1,54 @@
+/**
+ * DualEngine breakpoint-routing tests
+ *
+ * DualEngine must fan breakpoint mutations to both sub-engines (so a later
+ * engine switch preserves them) and relay onBreakpointHit from whichever engine
+ * is active. In node, WASM is unsupported, so the JS engine is always active and
+ * acts as the real-execution oracle.
+ */
+
+import { describe, it, expect } from 'vitest';
+import Bus from '../../Bus';
+import RAM from '../../RAM';
+import { DualEngine } from '../DualEngine';
+
+function makeDualEngine(): DualEngine {
+    const ram = new RAM(0xffff);
+    const bus = new Bus([{ component: ram, addr: [0x0000, 0xffff], name: 'RAM' }]);
+    // 'JS' initial engine: WASM is unavailable under node and would fall back anyway.
+    return new DualEngine(bus, 'JS');
+}
+
+describe('DualEngine breakpoint routing', () => {
+    it('set/clear/clearAll are reflected by the active engine', () => {
+        const engine = makeDualEngine();
+
+        engine.setBreakpoint(0x1234);
+        expect(engine.getBreakpoints()).toContain(0x1234);
+        expect(engine.hasBreakpoint(0x1234)).toBe(true);
+
+        engine.clearBreakpoint(0x1234);
+        expect(engine.getBreakpoints()).not.toContain(0x1234);
+
+        engine.setBreakpoint(0x1);
+        engine.setBreakpoint(0x2);
+        engine.clearAllBreakpoints();
+        expect(engine.getBreakpoints()).toEqual([]);
+    });
+
+    it('relays an active-engine breakpoint hit to a DualEngine subscriber', () => {
+        const engine = makeDualEngine();
+        engine.writeRange(0x0000, new Uint8Array(16).fill(0xea)); // NOPs
+        engine.writeRange(0xfffc, new Uint8Array([0x00, 0x00])); // reset vector -> 0x0000
+        engine.reset(); // PC <- reset vector (0x0000) on the active engine
+        engine.setBreakpoint(0x0002);
+
+        const hits: number[] = [];
+        engine.onBreakpointHit?.((addr) => hits.push(addr));
+
+        engine.performBulkSteps(100);
+
+        expect(hits).toEqual([0x0002]);
+        expect(engine.getRegisters().PC).toBe(0x0002);
+    });
+});

--- a/src/core/cpu-engines/__tests__/JSEngine-breakpoint-enforcement.vitest.test.ts
+++ b/src/core/cpu-engines/__tests__/JSEngine-breakpoint-enforcement.vitest.test.ts
@@ -1,0 +1,84 @@
+/**
+ * JSEngine breakpoint-enforcement tests
+ *
+ * The JS engine is the node-runnable parity oracle for the WASM engine. It must
+ * actually halt at a breakpoint (not merely log) and emit onBreakpointHit, and a
+ * single step must be able to advance *past* a breakpoint sitting on the current
+ * PC (so the debugger can step off a breakpoint).
+ */
+
+import { describe, it, expect } from 'vitest';
+import Bus from '../../Bus';
+import RAM from '../../RAM';
+import { JSEngine } from '../JSEngine';
+
+function makeEngine(): JSEngine {
+    const ram = new RAM(0xffff);
+    const bus = new Bus([{ component: ram, addr: [0x0000, 0xffff], name: 'RAM' }]);
+    const engine = new JSEngine(bus);
+    // Fill with NOP (0xEA, 2 cycles each) so PC walks forward predictably.
+    engine.writeRange(0x0000, new Uint8Array(32).fill(0xea));
+    return engine;
+}
+
+describe('JSEngine breakpoint enforcement', () => {
+    it('halts bulk execution at the breakpoint and fires onBreakpointHit once', () => {
+        const engine = makeEngine();
+        engine.setRegisters({ PC: 0x0000 });
+        engine.setBreakpoint(0x0003);
+
+        const hits: number[] = [];
+        engine.onBreakpointHit?.((addr) => hits.push(addr));
+
+        engine.performBulkSteps(100);
+
+        // Stopped *before* executing the instruction at the breakpoint.
+        expect(engine.getRegisters().PC).toBe(0x0003);
+        expect(hits).toEqual([0x0003]);
+    });
+
+    it('single-step advances past a breakpoint on the current PC without firing', () => {
+        const engine = makeEngine();
+        engine.setRegisters({ PC: 0x0003 });
+        engine.setBreakpoint(0x0003);
+
+        const hits: number[] = [];
+        engine.onBreakpointHit?.((addr) => hits.push(addr));
+
+        const cycles = engine.performSingleStep();
+
+        expect(cycles).toBeGreaterThan(0);
+        expect(engine.getRegisters().PC).toBe(0x0004);
+        expect(hits).toEqual([]);
+    });
+
+    it('does not halt once the breakpoint is cleared', () => {
+        const engine = makeEngine();
+        engine.setRegisters({ PC: 0x0000 });
+        engine.setBreakpoint(0x0003);
+        engine.clearBreakpoint(0x0003);
+
+        const hits: number[] = [];
+        engine.onBreakpointHit?.((addr) => hits.push(addr));
+
+        engine.performBulkSteps(10); // ~5 NOPs, would pass 0x0003
+
+        expect(hits).toEqual([]);
+        expect(engine.getRegisters().PC).toBeGreaterThan(0x0003);
+    });
+
+    it('unsubscribing stops further notifications', () => {
+        const engine = makeEngine();
+        engine.setRegisters({ PC: 0x0000 });
+        engine.setBreakpoint(0x0002);
+
+        const hits: number[] = [];
+        const unsub = engine.onBreakpointHit?.((addr) => hits.push(addr));
+        unsub?.();
+
+        engine.performBulkSteps(100);
+
+        expect(hits).toEqual([]);
+        expect(engine.getRegisters().PC).toBe(0x0002); // still halts execution
+    });
+});

--- a/src/core/cpu-interface/ICPUEngine.ts
+++ b/src/core/cpu-interface/ICPUEngine.ts
@@ -229,6 +229,16 @@ export interface ICPUEngine {
     hasBreakpoint(address: number): boolean;
 
     /**
+     * Subscribe to breakpoint-hit events. The engine invokes the listener with
+     * the PC of the breakpoint *before* that instruction executes, having halted
+     * execution. This is the single, engine-agnostic enforcement signal the
+     * worker wires to its pause/notify path — it works identically for the JS
+     * engine (CPU6502 execution hook) and the WASM engine (Rust-side check).
+     * @returns Unsubscribe function
+     */
+    onBreakpointHit?(callback: (address: number) => void): () => void;
+
+    /**
      * Get disassembly at current PC
      * @param instructionCount Number of instructions to disassemble
      * @returns Disassembled instructions

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '4.47.0';
+export const APP_VERSION = '4.47.1';


### PR DESCRIPTION
## Problem

Breakpoints did not pause execution on the **WASM engine — which is the default**, and worked on the JS engine only when it was the active engine. Run-to-cursor and single-step had the same defect.

**Root cause — split-brain enforcement.** The worker enforced breakpoints via a `CPU6502` execution hook installed on the JS engine's CPU *only* (`WorkerState`), while `WorkerAPI.setBreakpoint` never routed breakpoints into the active engine. So the WASM engine's Rust `HashSet` stayed empty, and even the Rust-side hit was only logged — never surfaced to pause the clock or notify the UI.

## Fix — unify enforcement in the engine layer

- **`ICPUEngine`**: add `onBreakpointHit()` hit-notification.
- **JSEngine**: enforce via its own `CPU6502` execution hook (installed only when breakpoints exist), emit `onBreakpointHit`, ignore the breakpoint on the current PC while single-stepping. Remove dead `console.log`.
- **WasmEngine**: emit `onBreakpointHit` on the Rust-reported hit (was log-only); lift the current-PC breakpoint across a single step so STEP isn't stuck.
- **DualEngine**: fan `onBreakpointHit` in from both engines; type `getInternalCPU` (no more `any`).
- **WorkerAPI**: route set/clear/clearAll to the active engine (**the missing wire**), add one engine-agnostic `handleBreakpointHit` (pause + notify + run-to-cursor), drive STEP through the active engine, model run-to-cursor as a transient engine breakpoint (previously JS-only).
- **WorkerState**: retire the JS-CPU-only execution-hook machinery.

No Rust change required (the single-step unstick is JS-side).

## Tests

Node-runnable; the JS engine is the WASM parity oracle, and fakes cover the worker routing/notify seam:

- `JSEngine-breakpoint-enforcement` — real execution halts at a breakpoint + emits once; single-step advances off it.
- `DualEngine-breakpoint-routing` — set/clear fan to the active engine; a hit reaches a DualEngine subscriber.
- `WorkerAPI-breakpoint-engine-routing` — set/clear/clearAll reach the active engine; an engine-reported hit pauses + notifies; stepping bypasses.
- `WorkerAPI-run-to-address` — run-to-cursor uses a transient engine breakpoint, cleared on arrival (preserves a coincident user breakpoint).

`yarn test:ci` green: lint + type-check + **730 passed / 19 skipped** (skipped = WASM-execution tests that only run in a browser).

## Manual browser verification (default WASM engine, v4.47.1)

Breakpoint at `$FF29` (WozMonitor keyboard loop): RUNNING→PAUSED with PC parked on the breakpoint; **Step** advanced off it (`$FF29`→`$FF2C`, breakpoint preserved); **Run** re-paused at `$FF29`; clearing the breakpoint let Run continue freely.

## Note

`getInternalCPU` was kept (not deleted) but **typed** — `Apple1.cpu` is load-bearing for state save/load under the dual engine, so deleting it would break `saveState`/`loadState`. Typing it satisfies the "no `any`" constraint without a state-management refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More consistent breakpoint detection and notifications across stepping and bulk execution, including when using the dual-engine path.
  * Run-to-cursor reliably installs/clears transient breakpoints and respects user breakpoints and no-engine cases.
  * Improved debugger stepping behavior to avoid stuck/duplicate breakpoint hits.

* **Tests**
  * Added coverage for breakpoint routing, enforcement, and run-to-cursor scenarios across engines.

* **Chores**
  * App version updated to 4.47.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stid/Apple1JS/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->