### PR TITLE
fix: extract VersionedStatefulComponentBase to de-duplicate state-load template

### DIFF
--- a/src/apple1/index.ts
+++ b/src/apple1/index.ts
@@ -1,7 +1,8 @@
 // Emulator state type for save/load
 import type { EmulatorState, PIAState, VideoState } from './TSTypes';
-import type { IVersionedStatefulComponent, StateValidationResult, StateOptions, StateBase } from '../core/types';
+import type { StateValidationResult, StateOptions, StateBase } from '../core/types';
 import { StateError } from '../core/types';
+import { VersionedStatefulComponentBase } from '../core/base/VersionedStatefulComponentBase';
 import CPU6502 from '../core/cpu6502';
 import { DualEngine } from '../core/cpu-engines';
 import type { ICPUEngine } from '../core/cpu-interface/ICPUEngine';
@@ -69,7 +70,8 @@ interface Apple1State extends StateBase {
     systemId: string;
 }
 
-class Apple1 implements IInspectableComponent, IVersionedStatefulComponent<Apple1State> {
+class Apple1 extends VersionedStatefulComponentBase<Apple1State> implements IInspectableComponent {
+    protected readonly stateComponentName = 'Apple1';
     /** Current state schema version */
     private static readonly STATE_VERSION = '2.0';
     // Keep old methods for backward compatibility but mark as deprecated
@@ -242,6 +244,7 @@ class Apple1 implements IInspectableComponent, IVersionedStatefulComponent<Apple
         keyboard: IoComponent;
         useDualEngine?: boolean;
     }) {
+        super();
         this.useDualEngine = useDualEngine;
         // Keyboard & Video are injected from the outside (browser vs nodejs). This make this core
         // implementation agnostic. They just need to conform to IOComponent interfaces.
@@ -442,22 +445,7 @@ class Apple1 implements IInspectableComponent, IVersionedStatefulComponent<Apple
     /**
      * Restore the Apple1 system from a saved state
      */
-    loadState(state: Apple1State, options?: StateOptions): void {
-        const opts = { validate: true, migrate: true, ...options };
-
-        if (opts.validate) {
-            const validation = this.validateState(state);
-            if (!validation.valid) {
-                throw new StateError(`Invalid Apple1 state: ${validation.errors.join(', ')}`, 'Apple1', 'load');
-            }
-        }
-
-        // Handle version migration if needed
-        let finalState = state;
-        if (opts.migrate && state.version && state.version !== Apple1.STATE_VERSION) {
-            finalState = this.migrateState(state, state.version);
-        }
-
+    protected applyState(finalState: Apple1State, opts: Required<StateOptions>): void {
         // Stop clock before loading state
         // Get running state from the current clock state
         const currentClockState = this.clock.saveState();

--- a/src/core/Clock.ts
+++ b/src/core/Clock.ts
@@ -12,9 +12,11 @@ const MAX_WAIT_TIME = 50;
 const TIMING_SAMPLE_SIZE = 100;
 const DRIFT_CORRECTION_THRESHOLD = 0.02; // More aggressive threshold
 
-import { IInspectableComponent, InspectableData, WithBusMetadata } from './types';
-import type { TimingStats, IVersionedStatefulComponent, StateValidationResult, StateOptions, StateBase } from './types';
+import { IInspectableComponent, InspectableData } from './types';
+import type { TimingStats, StateValidationResult, StateOptions, StateBase } from './types';
 import { StateError } from './types';
+import { VersionedStatefulComponentBase } from './base/VersionedStatefulComponentBase';
+import { baseInspectable } from './base/inspectable';
 
 /**
  * Clock state interface for serialization/deserialization
@@ -23,20 +25,20 @@ interface ClockState extends StateBase {
     /** Clock configuration */
     mhz: number;
     stepChunk: number;
-    
+
     /** Execution state */
     running: boolean;
     paused: boolean;
-    
+
     /** Timing state */
     provisionedCycles: number;
     maxedCycles: number;
     totalElapsedCycles: number;
-    
+
     /** Pause management */
     pausedAt: number;
     totalPausedTime: number;
-    
+
     /** Performance tracking */
     frameTimeSamples: number[];
     driftCompensation: number;
@@ -47,7 +49,8 @@ interface ClockState extends StateBase {
  * Clock class simulates a clock and allows subscribers to be notified of its changes.
  */
 
-class Clock implements PubSub<number>, IInspectableComponent, IVersionedStatefulComponent<ClockState> {
+class Clock extends VersionedStatefulComponentBase<ClockState> implements PubSub<number>, IInspectableComponent {
+    protected readonly stateComponentName = 'Clock';
     id = 'clock';
     type = 'Clock';
     name?: string;
@@ -71,6 +74,7 @@ class Clock implements PubSub<number>, IInspectableComponent, IVersionedStateful
     private static readonly STATE_VERSION = '2.0';
 
     constructor(mhz: number = DEFAULT_MHZ, stepChunk: number = DEFAULT_STEP_INTERVAL) {
+        super();
         this.mhz = mhz;
         this.stepChunk = stepChunk;
         this.provisionedCycles = 0;
@@ -96,15 +100,9 @@ class Clock implements PubSub<number>, IInspectableComponent, IVersionedStateful
      * Returns a standardized view of the Clock component.
      */
     getInspectable(): InspectableData {
-        const self = this as WithBusMetadata<typeof this>;
         const stats = this.getTimingStats();
-        
-        return {
-            id: this.id,
-            type: this.type,
-            name: this.name ?? '',
-            ...(self.__address !== undefined && { address: self.__address }),
-            ...(self.__addressName !== undefined && { addressName: self.__addressName }),
+
+        return baseInspectable(this, {
             state: {
                 mhz: this.mhz,
                 stepChunk: this.stepChunk,
@@ -117,7 +115,7 @@ class Clock implements PubSub<number>, IInspectableComponent, IVersionedStateful
                 drift: (stats.drift * 100).toFixed(2) + '%',
                 avgCycleTime: stats.avgCycleTime.toFixed(2) + 'ms',
                 totalCycles: stats.totalCycles,
-                totalTime: stats.totalTime.toFixed(2) + 's'
+                totalTime: stats.totalTime.toFixed(2) + 's',
             },
             // Backward compatibility - flat properties
             mhz: this.mhz,
@@ -128,7 +126,7 @@ class Clock implements PubSub<number>, IInspectableComponent, IVersionedStateful
             drift: (stats.drift * 100).toFixed(2) + '%',
             avgCycleTime: stats.avgCycleTime.toFixed(2) + 'ms',
             totalCycles: stats.totalCycles,
-        };
+        });
     }
 
     // Allows a function to subscribe to the clock's updates.
@@ -153,15 +151,15 @@ class Clock implements PubSub<number>, IInspectableComponent, IVersionedStateful
     toDebug(): { [key: string]: number | string | boolean } {
         const { mhz, stepChunk, provisionedCycles, maxedCycles } = this;
         const stats = this.getTimingStats();
-        return { 
-            mhz, 
-            stepChunk, 
-            provisionedCycles, 
+        return {
+            mhz,
+            stepChunk,
+            provisionedCycles,
             maxedCycles,
             actualFrequency: stats.actualFrequency,
             drift: stats.drift,
             running: this.running,
-            paused: this.paused
+            paused: this.paused,
         };
     }
 
@@ -209,10 +207,11 @@ class Clock implements PubSub<number>, IInspectableComponent, IVersionedStateful
         const actualFrequency = elapsedTime > 0 ? this.totalElapsedCycles / elapsedTime / 1000000 : 0;
         const targetFrequency = this.mhz;
         const drift = targetFrequency > 0 ? (actualFrequency - targetFrequency) / targetFrequency : 0;
-        
-        const avgCycleTime = this.frameTimeSamples.length > 0 
-            ? this.frameTimeSamples.reduce((a, b) => a + b, 0) / this.frameTimeSamples.length 
-            : 0;
+
+        const avgCycleTime =
+            this.frameTimeSamples.length > 0
+                ? this.frameTimeSamples.reduce((a, b) => a + b, 0) / this.frameTimeSamples.length
+                : 0;
 
         return {
             actualFrequency,
@@ -220,7 +219,7 @@ class Clock implements PubSub<number>, IInspectableComponent, IVersionedStateful
             drift,
             avgCycleTime,
             totalCycles: this.totalElapsedCycles,
-            totalTime: elapsedTime
+            totalTime: elapsedTime,
         };
     }
 
@@ -230,7 +229,7 @@ class Clock implements PubSub<number>, IInspectableComponent, IVersionedStateful
         if (Math.abs(stats.drift) > DRIFT_CORRECTION_THRESHOLD) {
             // More aggressive compensation: use 0.5x multiplier for drift
             this.driftCompensation = Math.max(0.3, Math.min(2.0, 1.0 - stats.drift * 0.5));
-            
+
             // Also adjust wait time dynamically
             if (stats.drift > 0) {
                 // Running too fast, increase wait time
@@ -265,7 +264,7 @@ class Clock implements PubSub<number>, IInspectableComponent, IVersionedStateful
 
             const currentTime = performance.now();
             const deltaTime = currentTime - this.lastFrameTime;
-            
+
             this.provisionedCycles = Math.floor(deltaTime * this.mhz * 1000 * this.driftCompensation);
             this.lastFrameTime = currentTime;
 
@@ -315,7 +314,7 @@ class Clock implements PubSub<number>, IInspectableComponent, IVersionedStateful
      */
     saveState(options?: StateOptions): ClockState {
         const opts = { includeDebugInfo: false, includeRuntimeState: false, ...options };
-        
+
         const state: ClockState = {
             version: Clock.STATE_VERSION,
             // Configuration
@@ -342,7 +341,7 @@ class Clock implements PubSub<number>, IInspectableComponent, IVersionedStateful
                 metadata: {
                     timestamp: Date.now(),
                     componentId: 'Clock',
-                }
+                },
             });
         }
 
@@ -350,28 +349,9 @@ class Clock implements PubSub<number>, IInspectableComponent, IVersionedStateful
     }
 
     /**
-     * Restore the Clock from a saved state
+     * Restore the Clock from an already-validated, already-migrated state.
      */
-    loadState(state: ClockState, options?: StateOptions): void {
-        const opts = { validate: true, migrate: true, ...options };
-        
-        if (opts.validate) {
-            const validation = this.validateState(state);
-            if (!validation.valid) {
-                throw new StateError(
-                    `Invalid Clock state: ${validation.errors.join(', ')}`,
-                    'Clock',
-                    'load'
-                );
-            }
-        }
-
-        // Handle version migration if needed
-        let finalState = state;
-        if (opts.migrate && state.version && state.version !== Clock.STATE_VERSION) {
-            finalState = this.migrateState(state, state.version);
-        }
-
+    protected applyState(finalState: ClockState): void {
         // Stop any running clock before loading state
         const wasRunning = this.running;
         if (wasRunning) {
@@ -460,7 +440,11 @@ class Clock implements PubSub<number>, IInspectableComponent, IVersionedStateful
         if (typeof s.driftCompensation !== 'number' || s.driftCompensation <= 0) {
             errors.push('driftCompensation must be a positive number');
         }
-        if (typeof s.dynamicWaitTime !== 'number' || s.dynamicWaitTime < MIN_WAIT_TIME || s.dynamicWaitTime > MAX_WAIT_TIME) {
+        if (
+            typeof s.dynamicWaitTime !== 'number' ||
+            s.dynamicWaitTime < MIN_WAIT_TIME ||
+            s.dynamicWaitTime > MAX_WAIT_TIME
+        ) {
             errors.push(`dynamicWaitTime must be between ${MIN_WAIT_TIME} and ${MAX_WAIT_TIME}`);
         }
 
@@ -532,15 +516,15 @@ class Clock implements PubSub<number>, IInspectableComponent, IVersionedStateful
                 // Version 1.0 didn't have: frameTimeSamples, driftCompensation, dynamicWaitTime
                 return {
                     version: Clock.STATE_VERSION,
-                    mhz: state.mhz as number ?? DEFAULT_MHZ,
-                    stepChunk: state.stepChunk as number ?? DEFAULT_STEP_INTERVAL,
-                    running: state.running as boolean ?? false,
-                    paused: state.paused as boolean ?? false,
-                    provisionedCycles: state.provisionedCycles as number ?? 0,
-                    maxedCycles: state.maxedCycles as number ?? 0,
-                    totalElapsedCycles: state.totalElapsedCycles as number ?? 0,
-                    pausedAt: state.pausedAt as number ?? 0,
-                    totalPausedTime: state.totalPausedTime as number ?? 0,
+                    mhz: (state.mhz as number) ?? DEFAULT_MHZ,
+                    stepChunk: (state.stepChunk as number) ?? DEFAULT_STEP_INTERVAL,
+                    running: (state.running as boolean) ?? false,
+                    paused: (state.paused as boolean) ?? false,
+                    provisionedCycles: (state.provisionedCycles as number) ?? 0,
+                    maxedCycles: (state.maxedCycles as number) ?? 0,
+                    totalElapsedCycles: (state.totalElapsedCycles as number) ?? 0,
+                    pausedAt: (state.pausedAt as number) ?? 0,
+                    totalPausedTime: (state.totalPausedTime as number) ?? 0,
                     // New fields added in v2.0
                     frameTimeSamples: [],
                     driftCompensation: 1.0,
@@ -548,11 +532,7 @@ class Clock implements PubSub<number>, IInspectableComponent, IVersionedStateful
                 };
 
             default:
-                throw new StateError(
-                    `Unsupported Clock state version: ${fromVersion}`,
-                    'Clock',
-                    'migrate'
-                );
+                throw new StateError(`Unsupported Clock state version: ${fromVersion}`, 'Clock', 'migrate');
         }
     }
 

--- a/src/core/PIA6820.ts
+++ b/src/core/PIA6820.ts
@@ -1,24 +1,34 @@
-import type { IInspectableComponent, InspectableData, InspectableChild, WithBusMetadata, IoComponent, subscribeFunction, IVersionedStatefulComponent, StateValidationResult, StateOptions, StateBase } from './types';
+import type {
+    IInspectableComponent,
+    InspectableData,
+    InspectableChild,
+    IoComponent,
+    subscribeFunction,
+    StateValidationResult,
+    StateOptions,
+    StateBase,
+} from './types';
 // formatByte is replaced by direct use of Formatters
 import { loggingService } from '../services/LoggingService';
-import { StateError } from './types';
 import { Formatters } from '../utils/formatters';
+import { VersionedStatefulComponentBase } from './base/VersionedStatefulComponentBase';
+import { baseInspectable } from './base/inspectable';
 
 // Use global performance API
 declare const performance: { now(): number };
 
 // PIA Registers - Apple 1 memory mapping
-const REG_ORA_DDRA = 0x0;  // $D010 - Output Register A / Data Direction Register A
-const REG_CRA = 0x1;       // $D011 - Control Register A
-const REG_ORB_DDRB = 0x2;  // $D012 - Output Register B / Data Direction Register B
-const REG_CRB = 0x3;       // $D013 - Control Register B
+const REG_ORA_DDRA = 0x0; // $D010 - Output Register A / Data Direction Register A
+const REG_CRA = 0x1; // $D011 - Control Register A
+const REG_ORB_DDRB = 0x2; // $D012 - Output Register B / Data Direction Register B
+const REG_CRB = 0x3; // $D013 - Control Register B
 
 // Control Register bit definitions
-const CR_IRQ1 = 7;         // IRQ1 flag (CA1/CB1 active transition occurred)
-const CR_IRQ2 = 6;         // IRQ2 flag (CA2/CB2 active transition occurred, if input)
-const CR_CA2_CB2_DIR = 5;  // CA2/CB2 direction (0=input, 1=output)
+const CR_IRQ1 = 7; // IRQ1 flag (CA1/CB1 active transition occurred)
+const CR_IRQ2 = 6; // IRQ2 flag (CA2/CB2 active transition occurred, if input)
+const CR_CA2_CB2_DIR = 5; // CA2/CB2 direction (0=input, 1=output)
 // const CR_CA2_CB2_CTRL = 3; // CA2/CB2 control (2 bits: 3-4) - Reserved for future use
-const CR_DDR_ACCESS = 2;   // DDR access control (0=DDR selected, 1=Output Register selected)
+const CR_DDR_ACCESS = 2; // DDR access control (0=DDR selected, 1=Output Register selected)
 // const CR_CA1_CB1_CTRL = 0; // CA1/CB1 control (2 bits: 0-1) - Reserved for future use
 
 /**
@@ -56,7 +66,7 @@ interface PIA6820State extends StateBase {
 
 /**
  * MC6820/6821 Peripheral Interface Adapter (PIA) emulation.
- * 
+ *
  * The PIA provides two 8-bit bidirectional I/O ports (A and B) with handshaking
  * control lines (CA1/CA2, CB1/CB2). In the Apple 1:
  * - Port A is connected to the keyboard (input)
@@ -64,18 +74,19 @@ interface PIA6820State extends StateBase {
  * - CA1 is used for keyboard strobe
  * - CB2 is wired to PB7 for display handshaking
  */
-class PIA6820 implements IInspectableComponent, IVersionedStatefulComponent<PIA6820State> {
+class PIA6820 extends VersionedStatefulComponentBase<PIA6820State> implements IInspectableComponent {
+    protected readonly stateComponentName = 'PIA6820';
     id = 'pia6820';
     type = 'PIA6820';
     name?: string;
 
     // Internal registers
-    private ora = 0x00;     // Output Register A
-    private orb = 0x00;     // Output Register B
-    private ddra = 0x00;    // Data Direction Register A (0=input, 1=output)
-    private ddrb = 0x00;    // Data Direction Register B
-    private cra = 0x00;     // Control Register A
-    private crb = 0x00;     // Control Register B
+    private ora = 0x00; // Output Register A
+    private orb = 0x00; // Output Register B
+    private ddra = 0x00; // Data Direction Register A (0=input, 1=output)
+    private ddrb = 0x00; // Data Direction Register B
+    private cra = 0x00; // Control Register A
+    private crb = 0x00; // Control Register B
 
     // Control line states
     private ca1 = false;
@@ -115,6 +126,7 @@ class PIA6820 implements IInspectableComponent, IVersionedStatefulComponent<PIA6
     private static readonly STATE_VERSION = '3.0';
 
     constructor() {
+        super();
         // Initialize PIA registers to proper Apple 1 state
         this.ora = 0x00;
         this.orb = 0x00;
@@ -122,11 +134,11 @@ class PIA6820 implements IInspectableComponent, IVersionedStatefulComponent<PIA6
         // Port A: all inputs (keyboard)
         this.ddra = 0x00;
         // Port B: bits 0-6 outputs (display data), bit 7 input (display status)
-        this.ddrb = 0x7F;
+        this.ddrb = 0x7f;
         // Set CRA and CRB bit 2 to access Output Registers (not DDR)
         this.cra = 0x04; // Bit 2 = 1 to access ORA
         this.crb = 0x04; // Bit 2 = 1 to access ORB
-        
+
         // Initialize control lines
         this.ca1 = false;
         this.ca2 = false;
@@ -177,7 +189,7 @@ class PIA6820 implements IInspectableComponent, IVersionedStatefulComponent<PIA6
                 // Clear CA1 interrupt flag when reading port A
                 this.cra &= ~(1 << CR_IRQ1);
                 // Return DDR or Output Register based on CRA bit 2
-                result = (this.cra & (1 << CR_DDR_ACCESS)) ? this.readPortA() : this.ddra;
+                result = this.cra & (1 << CR_DDR_ACCESS) ? this.readPortA() : this.ddra;
                 break;
 
             case REG_CRA:
@@ -188,7 +200,7 @@ class PIA6820 implements IInspectableComponent, IVersionedStatefulComponent<PIA6
                 // Clear CB1 interrupt flag when reading port B
                 this.crb &= ~(1 << CR_IRQ1);
                 // Return DDR or Output Register based on CRB bit 2
-                result = (this.crb & (1 << CR_DDR_ACCESS)) ? this.readPortB() : this.ddrb;
+                result = this.crb & (1 << CR_DDR_ACCESS) ? this.readPortB() : this.ddrb;
                 break;
 
             case REG_CRB:
@@ -216,7 +228,7 @@ class PIA6820 implements IInspectableComponent, IVersionedStatefulComponent<PIA6
         }
 
         // Ensure 8-bit value
-        value = value & 0xFF;
+        value = value & 0xff;
 
         // Track if we need to notify
         let valueChanged = false;
@@ -243,7 +255,7 @@ class PIA6820 implements IInspectableComponent, IVersionedStatefulComponent<PIA6
 
             case REG_CRA: {
                 // Bits 6-7 are read-only interrupt flags
-                const newCra = (this.cra & 0xC0) | (value & 0x3F);
+                const newCra = (this.cra & 0xc0) | (value & 0x3f);
                 if (this.cra !== newCra) {
                     this.cra = newCra;
                     valueChanged = true;
@@ -271,7 +283,7 @@ class PIA6820 implements IInspectableComponent, IVersionedStatefulComponent<PIA6
 
             case REG_CRB: {
                 // Bits 6-7 are read-only interrupt flags
-                const newCrb = (this.crb & 0xC0) | (value & 0x3F);
+                const newCrb = (this.crb & 0xc0) | (value & 0x3f);
                 if (this.crb !== newCrb) {
                     this.crb = newCrb;
                     valueChanged = true;
@@ -297,7 +309,7 @@ class PIA6820 implements IInspectableComponent, IVersionedStatefulComponent<PIA6
         this.ca1 = state;
 
         if (this.detectCA1Transition()) {
-            this.cra |= (1 << CR_IRQ1);
+            this.cra |= 1 << CR_IRQ1;
             // Use batched notification to prevent recursion
             this.notificationBatch.add('ca1');
             this.scheduleNotification();
@@ -313,7 +325,7 @@ class PIA6820 implements IInspectableComponent, IVersionedStatefulComponent<PIA6
         this.cb1 = state;
 
         if (this.detectCB1Transition()) {
-            this.crb |= (1 << CR_IRQ1);
+            this.crb |= 1 << CR_IRQ1;
             // Use batched notification to prevent recursion
             this.notificationBatch.add('cb1');
             this.scheduleNotification();
@@ -330,7 +342,7 @@ class PIA6820 implements IInspectableComponent, IVersionedStatefulComponent<PIA6
             this.ca2 = state;
 
             if (this.detectCA2Transition()) {
-                this.cra |= (1 << CR_IRQ2);
+                this.cra |= 1 << CR_IRQ2;
                 // Use batched notification to prevent recursion
                 this.notificationBatch.add('ca2');
                 this.scheduleNotification();
@@ -348,7 +360,7 @@ class PIA6820 implements IInspectableComponent, IVersionedStatefulComponent<PIA6
             this.cb2 = state;
 
             if (this.detectCB2Transition()) {
-                this.crb |= (1 << CR_IRQ2);
+                this.crb |= 1 << CR_IRQ2;
                 // Use batched notification to prevent recursion
                 this.notificationBatch.add('cb2');
                 this.scheduleNotification();
@@ -377,7 +389,7 @@ class PIA6820 implements IInspectableComponent, IVersionedStatefulComponent<PIA6
         const irq2Enable = (this.cra & 0x08) !== 0;
         const irq1Active = (this.cra & 0x80) !== 0;
         const irq2Active = (this.cra & 0x40) !== 0;
-        
+
         return (irq1Enable && irq1Active) || (irq2Enable && irq2Active);
     }
 
@@ -389,7 +401,7 @@ class PIA6820 implements IInspectableComponent, IVersionedStatefulComponent<PIA6
         const irq2Enable = (this.crb & 0x08) !== 0;
         const irq1Active = (this.crb & 0x80) !== 0;
         const irq2Active = (this.crb & 0x40) !== 0;
-        
+
         return (irq1Enable && irq1Active) || (irq2Enable && irq2Active);
     }
 
@@ -428,7 +440,7 @@ class PIA6820 implements IInspectableComponent, IVersionedStatefulComponent<PIA6
      */
     saveState(options?: StateOptions): PIA6820State {
         const opts = { includeDebugInfo: false, ...options };
-        
+
         const state: PIA6820State = {
             version: PIA6820.STATE_VERSION,
             // Core registers
@@ -463,8 +475,8 @@ class PIA6820 implements IInspectableComponent, IVersionedStatefulComponent<PIA6
                     type: this.type,
                     name: this.name,
                     stats: { ...this.stats },
-                    cacheSize: this.registerCache.size
-                }
+                    cacheSize: this.registerCache.size,
+                },
             });
         }
 
@@ -472,28 +484,9 @@ class PIA6820 implements IInspectableComponent, IVersionedStatefulComponent<PIA6
     }
 
     /**
-     * Load PIA state with validation and migration support
+     * Load PIA state from an already-validated, already-migrated state.
      */
-    loadState(state: PIA6820State, options?: StateOptions): void {
-        const opts = { validate: true, migrate: true, ...options };
-        
-        if (opts.validate) {
-            const validation = this.validateState(state);
-            if (!validation.valid) {
-                throw new StateError(
-                    `Invalid PIA6820 state: ${validation.errors.join(', ')}`, 
-                    'PIA6820', 
-                    'load'
-                );
-            }
-        }
-
-        // Handle version migration if needed
-        let finalState = state;
-        if (opts.migrate && state.version && state.version !== PIA6820.STATE_VERSION) {
-            finalState = this.migrateState(state, state.version);
-        }
-        
+    protected applyState(finalState: PIA6820State): void {
         // Load core registers
         this.ora = finalState.ora;
         this.orb = finalState.orb;
@@ -514,14 +507,14 @@ class PIA6820 implements IInspectableComponent, IVersionedStatefulComponent<PIA6
 
         // Load hardware-controlled input pins
         this.pb7InputState = finalState.pb7InputState;
-        
+
         // CRITICAL: Always clear the display busy bit after loading state
         // If the state was saved while the display was processing a character (pb7InputState = true),
         // the WOZ Monitor will be stuck in an infinite loop waiting for the display to become ready.
         // Since we're loading a saved state, any pending display operation would have been lost anyway,
         // so it's safe to mark the display as ready.
         this.pb7InputState = false;
-        
+
         this.notifySubscribers();
     }
 
@@ -593,11 +586,11 @@ class PIA6820 implements IInspectableComponent, IVersionedStatefulComponent<PIA6
         // Port A: all inputs (keyboard)
         this.ddra = 0x00;
         // Port B: bits 0-6 outputs (display data), bit 7 input (display status)
-        this.ddrb = 0x7F;
+        this.ddrb = 0x7f;
         // Set CRA and CRB bit 2 to access Output Registers (not DDR)
         this.cra = 0x04; // Bit 2 = 1 to access ORA
         this.crb = 0x04; // Bit 2 = 1 to access ORB
-        
+
         this.ca1 = false;
         this.ca2 = false;
         this.cb1 = false;
@@ -674,7 +667,6 @@ class PIA6820 implements IInspectableComponent, IVersionedStatefulComponent<PIA6
      * Returns a standardized view of the PIA6820 component.
      */
     getInspectable(): InspectableData {
-        const self = this as WithBusMetadata<typeof this>;
         const uptime = (performance.now() - this.stats.startTime) / 1000;
         const opsPerSecond = uptime > 0 ? (this.stats.reads + this.stats.writes) / uptime : 0;
 
@@ -682,22 +674,17 @@ class PIA6820 implements IInspectableComponent, IVersionedStatefulComponent<PIA6
             const childObj: InspectableChild = {
                 id: child.id,
                 type: child.type || 'IoComponent',
-                name: child.name ?? ''
+                name: child.name ?? '',
             };
-            
+
             if (typeof child.getInspectable === 'function') {
                 childObj.component = child.getInspectable();
             }
-            
+
             return childObj;
         });
 
-        return {
-            id: this.id,
-            type: this.type,
-            name: this.name ?? '',
-            ...(self.__address !== undefined && { address: self.__address }),
-            ...(self.__addressName !== undefined && { addressName: self.__addressName }),
+        return baseInspectable(this, {
             state: {
                 // Registers
                 'Port A Data': Formatters.hexByte(this.ora),
@@ -708,12 +695,12 @@ class PIA6820 implements IInspectableComponent, IVersionedStatefulComponent<PIA6
                 'Port B Control': Formatters.hexByte(this.crb),
                 // Control Lines
                 'CA1 (Kbd Strobe)': this.ca1 ? 'HIGH' : 'LOW',
-                'CA2': this.ca2 ? 'HIGH' : 'LOW',
-                'CB1': this.cb1 ? 'HIGH' : 'LOW',
-                'CB2': this.cb2 ? 'HIGH' : 'LOW',
+                CA2: this.ca2 ? 'HIGH' : 'LOW',
+                CB1: this.cb1 ? 'HIGH' : 'LOW',
+                CB2: this.cb2 ? 'HIGH' : 'LOW',
                 // Interrupts
-                'IRQA': this.getIRQA() ? 'ACTIVE' : 'INACTIVE',
-                'IRQB': this.getIRQB() ? 'ACTIVE' : 'INACTIVE',
+                IRQA: this.getIRQA() ? 'ACTIVE' : 'INACTIVE',
+                IRQB: this.getIRQB() ? 'ACTIVE' : 'INACTIVE',
             },
             stats: {
                 reads: this.stats.reads,
@@ -724,8 +711,8 @@ class PIA6820 implements IInspectableComponent, IVersionedStatefulComponent<PIA6
                 cacheSize: this.registerCache.size,
                 cacheStatus: this.registerCache.size > 0 ? 'Active' : 'Empty',
             },
-            ...(children.length > 0 && { children })
-        };
+            ...(children.length > 0 && { children }),
+        });
     }
 
     /**
@@ -776,34 +763,34 @@ class PIA6820 implements IInspectableComponent, IVersionedStatefulComponent<PIA6
         // Output bits (DDR=1) come from ORB
         // Input bits (DDR=0) come from external hardware sources
         let result = this.orb & this.ddrb; // Output bits only
-        
+
         // Bit 7 is special - it's the display ready status controlled by display hardware
         if ((this.ddrb & 0x80) === 0) {
             // Bit 7 is input, read the hardware-controlled state
             result |= this.pb7InputState ? 0x80 : 0x00;
         }
-        
+
         return result;
     }
 
     private detectCA1Transition(): boolean {
         const edge = (this.cra & 0x02) !== 0; // Bit 1: 0=negative edge, 1=positive edge
-        return edge ? (!this.prevCa1 && this.ca1) : (this.prevCa1 && !this.ca1);
+        return edge ? !this.prevCa1 && this.ca1 : this.prevCa1 && !this.ca1;
     }
 
     private detectCB1Transition(): boolean {
         const edge = (this.crb & 0x02) !== 0;
-        return edge ? (!this.prevCb1 && this.cb1) : (this.prevCb1 && !this.cb1);
+        return edge ? !this.prevCb1 && this.cb1 : this.prevCb1 && !this.cb1;
     }
 
     private detectCA2Transition(): boolean {
         const edge = (this.cra & 0x10) !== 0; // Bit 4: edge for CA2 as input
-        return edge ? (!this.prevCa2 && this.ca2) : (this.prevCa2 && !this.ca2);
+        return edge ? !this.prevCa2 && this.ca2 : this.prevCa2 && !this.ca2;
     }
 
     private detectCB2Transition(): boolean {
         const edge = (this.crb & 0x10) !== 0;
-        return edge ? (!this.prevCb2 && this.cb2) : (this.prevCb2 && !this.cb2);
+        return edge ? !this.prevCb2 && this.cb2 : this.prevCb2 && !this.cb2;
     }
 
     private updateCA2Output(): void {
@@ -815,7 +802,7 @@ class PIA6820 implements IInspectableComponent, IVersionedStatefulComponent<PIA6
     }
 
     private updateCB2Output(): void {
-        // Update CB2 if configured as output  
+        // Update CB2 if configured as output
         if (this.crb & (1 << CR_CA2_CB2_DIR)) {
             // const mode = (this.crb >> 3) & 0x07;
             // TODO: Implement CB2 output modes if needed for full 6820 compliance
@@ -837,7 +824,7 @@ class PIA6820 implements IInspectableComponent, IVersionedStatefulComponent<PIA6
      */
     private scheduleNotification(): void {
         if (this.pendingNotification) return;
-        
+
         this.pendingNotification = true;
         // Use microtask to batch notifications within the same execution cycle
         globalThis.queueMicrotask(() => {

--- a/src/core/RAM.ts
+++ b/src/core/RAM.ts
@@ -1,7 +1,9 @@
 import { IInspectableComponent, InspectableData, WithBusMetadata, IoAddressable } from './types';
 import { loggingService } from '../services/LoggingService';
 import { DEFAULT_RAM_BANK_SIZE, MIN_BYTE_VALUE, MAX_BYTE_VALUE, BYTE_MASK } from './constants/memory';
-import { IVersionedStatefulComponent, StateValidationResult, StateOptions, StateError, StateBase } from './types';
+import { StateValidationResult, StateOptions, StateError, StateBase } from './types';
+import { VersionedStatefulComponentBase } from './base/VersionedStatefulComponentBase';
+import { baseInspectable } from './base/inspectable';
 
 /**
  * RAM state interface
@@ -15,23 +17,25 @@ interface RAMState extends StateBase {
     componentId: string;
 }
 
-class RAM implements IoAddressable, IInspectableComponent, IVersionedStatefulComponent<RAMState> {
+class RAM extends VersionedStatefulComponentBase<RAMState> implements IoAddressable, IInspectableComponent {
     /**
      * Current state version for RAM component
      */
     private static readonly STATE_VERSION = '2.0';
+
+    protected readonly stateComponentName = 'RAM';
 
     /**
      * Returns a serializable copy of the RAM contents.
      */
     saveState(options?: StateOptions): RAMState {
         const opts = { includeDebugInfo: false, ...options };
-        
+
         const state: RAMState = {
             version: RAM.STATE_VERSION,
             data: Array.from(this.data),
             size: this.data.length,
-            componentId: this.id
+            componentId: this.id,
         };
 
         if (opts.includeDebugInfo) {
@@ -40,8 +44,8 @@ class RAM implements IoAddressable, IInspectableComponent, IVersionedStatefulCom
                     timestamp: Date.now(),
                     componentId: this.id,
                     type: this.type,
-                    name: this.name
-                }
+                    name: this.name,
+                },
             });
         }
 
@@ -49,34 +53,15 @@ class RAM implements IoAddressable, IInspectableComponent, IVersionedStatefulCom
     }
 
     /**
-     * Restores RAM contents from a previously saved state.
+     * Restores RAM contents from an already-validated, already-migrated state.
      */
-    loadState(state: RAMState, options?: StateOptions): void {
-        const opts = { validate: true, migrate: true, ...options };
-        
-        if (opts.validate) {
-            const validation = this.validateState(state);
-            if (!validation.valid) {
-                throw new StateError(
-                    `Invalid RAM state: ${validation.errors.join(', ')}`, 
-                    'RAM', 
-                    'load'
-                );
-            }
-        }
-
-        // Handle version migration if needed
-        let finalState = state;
-        if (opts.migrate && state.version && state.version !== RAM.STATE_VERSION) {
-            finalState = this.migrateState(state, state.version);
-        }
-
+    protected applyState(finalState: RAMState): void {
         // Validate size compatibility
         if (finalState.data.length !== this.data.length) {
             throw new StateError(
                 `RAM size mismatch: expected ${this.data.length}, got ${finalState.data.length}`,
                 'RAM',
-                'load'
+                'load',
             );
         }
 
@@ -93,19 +78,13 @@ class RAM implements IoAddressable, IInspectableComponent, IVersionedStatefulCom
      * Returns a serializable architecture view of the RAM, suitable for inspectors.
      */
     getInspectable(): InspectableData {
-        const self = this as WithBusMetadata<typeof this>;
-        return {
-            id: this.id,
-            type: this.type,
-            name: this.name ?? '',
-            ...(self.__address !== undefined && { address: self.__address }),
-            ...(self.__addressName !== undefined && { addressName: self.__addressName }),
+        return baseInspectable(this, {
             size: this.data.length,
             state: {
                 size: this.data.length + ' bytes',
-                initialized: true
-            }
-        };
+                initialized: true,
+            },
+        });
     }
     private data: Uint8Array;
     get details() {
@@ -118,6 +97,7 @@ class RAM implements IoAddressable, IInspectableComponent, IVersionedStatefulCom
         };
     }
     constructor(byteSize: number = DEFAULT_RAM_BANK_SIZE) {
+        super();
         this.data = new Uint8Array(byteSize);
     }
 
@@ -144,9 +124,11 @@ class RAM implements IoAddressable, IInspectableComponent, IVersionedStatefulCom
                 .map((value, index) => ({ value, index }))
                 .filter(({ value }) => typeof value !== 'number' || value < 0 || value > 255)
                 .map(({ index }) => index);
-            
+
             if (invalidIndices.length > 0) {
-                errors.push(`Invalid byte values at indices: ${invalidIndices.slice(0, 5).join(', ')}${invalidIndices.length > 5 ? '...' : ''}`);
+                errors.push(
+                    `Invalid byte values at indices: ${invalidIndices.slice(0, 5).join(', ')}${invalidIndices.length > 5 ? '...' : ''}`,
+                );
             }
         }
 
@@ -254,7 +236,10 @@ class RAM implements IoAddressable, IInspectableComponent, IVersionedStatefulCom
         }
 
         if (prgAddr + coreData.length > this.data.length) {
-            loggingService.error('RAM', `Flash data would write outside bounds (addr: ${prgAddr}, len: ${coreData.length})`);
+            loggingService.error(
+                'RAM',
+                `Flash data would write outside bounds (addr: ${prgAddr}, len: ${coreData.length})`,
+            );
             return;
         }
 

--- a/src/core/ROM.ts
+++ b/src/core/ROM.ts
@@ -1,8 +1,10 @@
-import { IInspectableComponent, InspectableData, WithBusMetadata, IoAddressable } from './types';
+import { IInspectableComponent, InspectableData, IoAddressable } from './types';
 import { loggingService } from '../services/LoggingService';
 import { Formatters } from '../utils/formatters';
 import { DEFAULT_ROM_SIZE, MIN_BYTE_VALUE, BYTE_MASK } from './constants/memory';
-import { IVersionedStatefulComponent, StateValidationResult, StateOptions, StateError, StateBase } from './types';
+import { StateValidationResult, StateOptions, StateError, StateBase } from './types';
+import { VersionedStatefulComponentBase } from './base/VersionedStatefulComponentBase';
+import { baseInspectable } from './base/inspectable';
 
 /**
  * ROM state interface
@@ -19,7 +21,8 @@ interface ROMState extends StateBase {
     initialized: boolean;
 }
 
-class ROM implements IoAddressable, IInspectableComponent, IVersionedStatefulComponent<ROMState> {
+class ROM extends VersionedStatefulComponentBase<ROMState> implements IoAddressable, IInspectableComponent {
+    protected readonly stateComponentName = 'ROM';
     id = 'rom';
     type = 'ROM';
     name?: string;
@@ -31,19 +34,13 @@ class ROM implements IoAddressable, IInspectableComponent, IVersionedStatefulCom
      * Returns a serializable architecture view of the ROM, suitable for inspectors.
      */
     getInspectable(): InspectableData {
-        const self = this as WithBusMetadata<typeof this>;
-        return {
-            id: this.id,
-            type: this.type,
-            name: this.name ?? '',
-            ...(self.__address !== undefined && { address: self.__address }),
-            ...(self.__addressName !== undefined && { addressName: self.__addressName }),
+        return baseInspectable(this, {
             size: this.data.length,
             state: {
                 size: this.data.length + ' bytes',
-                readOnly: true
-            }
-        };
+                readOnly: true,
+            },
+        });
     }
     private data: Uint8Array;
     private _initialized = false;
@@ -62,6 +59,7 @@ class ROM implements IoAddressable, IInspectableComponent, IVersionedStatefulCom
     }
 
     constructor(byteSize: number = DEFAULT_ROM_SIZE) {
+        super();
         this.data = new Uint8Array(byteSize).fill(MIN_BYTE_VALUE);
     }
 
@@ -70,13 +68,13 @@ class ROM implements IoAddressable, IInspectableComponent, IVersionedStatefulCom
      */
     saveState(options?: StateOptions): ROMState {
         const opts = { includeDebugInfo: false, ...options };
-        
+
         const state: ROMState = {
             version: ROM.STATE_VERSION,
             data: Array.from(this.data),
             size: this.data.length,
             componentId: this.id,
-            initialized: this._initialized
+            initialized: this._initialized,
         };
 
         if (opts.includeDebugInfo) {
@@ -85,8 +83,8 @@ class ROM implements IoAddressable, IInspectableComponent, IVersionedStatefulCom
                     timestamp: Date.now(),
                     componentId: this.id,
                     type: this.type,
-                    name: this.name
-                }
+                    name: this.name,
+                },
             });
         }
 
@@ -94,34 +92,16 @@ class ROM implements IoAddressable, IInspectableComponent, IVersionedStatefulCom
     }
 
     /**
-     * Load ROM state - recreates ROM contents
+     * Load ROM state - recreates ROM contents from an already-validated,
+     * already-migrated state.
      */
-    loadState(state: ROMState, options?: StateOptions): void {
-        const opts = { validate: true, migrate: true, ...options };
-        
-        if (opts.validate) {
-            const validation = this.validateState(state);
-            if (!validation.valid) {
-                throw new StateError(
-                    `Invalid ROM state: ${validation.errors.join(', ')}`, 
-                    'ROM', 
-                    'load'
-                );
-            }
-        }
-
-        // Handle version migration if needed
-        let finalState = state;
-        if (opts.migrate && state.version && state.version !== ROM.STATE_VERSION) {
-            finalState = this.migrateState(state, state.version);
-        }
-
+    protected applyState(finalState: ROMState): void {
         // Validate size compatibility
         if (finalState.data.length !== this.data.length) {
             throw new StateError(
                 `ROM size mismatch: expected ${this.data.length}, got ${finalState.data.length}`,
                 'ROM',
-                'load'
+                'load',
             );
         }
 
@@ -152,9 +132,11 @@ class ROM implements IoAddressable, IInspectableComponent, IVersionedStatefulCom
                 .map((value, index) => ({ value, index }))
                 .filter(({ value }) => typeof value !== 'number' || value < 0 || value > 255)
                 .map(({ index }) => index);
-            
+
             if (invalidIndices.length > 0) {
-                errors.push(`Invalid byte values at indices: ${invalidIndices.slice(0, 5).join(', ')}${invalidIndices.length > 5 ? '...' : ''}`);
+                errors.push(
+                    `Invalid byte values at indices: ${invalidIndices.slice(0, 5).join(', ')}${invalidIndices.length > 5 ? '...' : ''}`,
+                );
             }
         }
 

--- a/src/core/base/VersionedStatefulComponentBase.ts
+++ b/src/core/base/VersionedStatefulComponentBase.ts
@@ -1,0 +1,71 @@
+/**
+ * Base class for versioned, stateful emulated-hardware components.
+ *
+ * Every core component (RAM, ROM, Clock, PIA6820, Apple1) used to hand-roll the
+ * identical `loadState` preamble: validate (optional) -> migrate if the stored
+ * version differs -> apply. This template method fixes that invariant sequence
+ * once and defers only the component-specific application to {@link applyState},
+ * so a fix to the validate/migrate guard lands in a single place.
+ *
+ * Subclasses keep ownership of `saveState`, `validateState`, `migrateState`,
+ * `resetState`, `getStateVersion`, and `getSupportedVersions` — those are
+ * genuinely per-component. They implement `applyState` (the body that used to
+ * follow the preamble) and expose `stateComponentName` for error messages.
+ */
+import {
+    IVersionedStatefulComponent,
+    StateBase,
+    StateOptions,
+    StateValidationResult,
+    StateError,
+    StateManager,
+} from '../types';
+
+export abstract class VersionedStatefulComponentBase<
+    TState extends StateBase,
+> implements IVersionedStatefulComponent<TState> {
+    /** Human-readable label used in {@link StateError} messages (e.g. 'RAM'). */
+    protected abstract readonly stateComponentName: string;
+
+    abstract saveState(options?: StateOptions): TState;
+    abstract validateState(state: unknown): StateValidationResult;
+    abstract migrateState(oldState: StateBase, fromVersion: string): TState;
+    abstract getStateVersion(): string;
+    abstract getSupportedVersions(): string[];
+    abstract resetState(): void;
+
+    /**
+     * Apply an already-validated, already-migrated state to the component.
+     * This is the part that used to follow the duplicated preamble in each class.
+     */
+    protected abstract applyState(state: TState, options: Required<StateOptions>): void;
+
+    loadState(state: TState, options?: StateOptions): void {
+        const opts = { ...StateManager.defaultStateOptions(), ...options };
+        const finalState = this.prepareLoad(state, opts);
+        this.applyState(finalState, opts);
+    }
+
+    /**
+     * Validate (when requested) and migrate (when the stored version differs)
+     * a state object, returning the state that should be applied.
+     */
+    protected prepareLoad(state: TState, opts: Required<StateOptions>): TState {
+        if (opts.validate) {
+            const validation = this.validateState(state);
+            if (!validation.valid) {
+                throw new StateError(
+                    `Invalid ${this.stateComponentName} state: ${validation.errors.join(', ')}`,
+                    this.stateComponentName,
+                    'load',
+                );
+            }
+        }
+
+        if (opts.migrate && state.version && state.version !== this.getStateVersion()) {
+            return this.migrateState(state, state.version);
+        }
+
+        return state;
+    }
+}

--- a/src/core/base/__tests__/VersionedStatefulComponentBase-template.vitest.test.ts
+++ b/src/core/base/__tests__/VersionedStatefulComponentBase-template.vitest.test.ts
@@ -1,0 +1,128 @@
+import { VersionedStatefulComponentBase } from '../VersionedStatefulComponentBase';
+import { baseInspectable } from '../inspectable';
+import { StateError } from '../../types';
+import type { StateBase, StateOptions, StateValidationResult } from '../../types';
+import type { InspectableData, WithBusMetadata } from '../../types';
+
+interface FakeState extends StateBase {
+    value: number;
+}
+
+/**
+ * Minimal concrete subclass that records how the base template drives it, so we
+ * can assert the validate -> migrate -> apply sequence without a real component.
+ */
+class FakeComponent extends VersionedStatefulComponentBase<FakeState> {
+    protected readonly stateComponentName = 'Fake';
+
+    // Test spies / knobs
+    valid = true;
+    applied: FakeState | null = null;
+    migrateCalledWith: { from: string } | null = null;
+
+    static readonly STATE_VERSION = '2.0';
+
+    saveState(): FakeState {
+        return { version: FakeComponent.STATE_VERSION, value: this.applied?.value ?? 0 };
+    }
+
+    validateState(): StateValidationResult {
+        return this.valid
+            ? { valid: true, errors: [], warnings: [] }
+            : { valid: false, errors: ['bad value'], warnings: [] };
+    }
+
+    migrateState(oldState: StateBase, fromVersion: string): FakeState {
+        this.migrateCalledWith = { from: fromVersion };
+        return { ...(oldState as FakeState), version: FakeComponent.STATE_VERSION, value: 999 };
+    }
+
+    getStateVersion(): string {
+        return FakeComponent.STATE_VERSION;
+    }
+
+    getSupportedVersions(): string[] {
+        return ['1.0', '2.0'];
+    }
+
+    resetState(): void {
+        this.applied = null;
+    }
+
+    protected applyState(state: FakeState): void {
+        this.applied = state;
+    }
+}
+
+describe('VersionedStatefulComponentBase template', () => {
+    it('applies a valid, current-version state directly (no migration)', () => {
+        const c = new FakeComponent();
+        c.loadState({ version: '2.0', value: 42 });
+        expect(c.applied).toEqual({ version: '2.0', value: 42 });
+        expect(c.migrateCalledWith).toBeNull();
+    });
+
+    it('throws a StateError tagged with the component name when validation fails', () => {
+        const c = new FakeComponent();
+        c.valid = false;
+        const thrown = (() => {
+            try {
+                c.loadState({ version: '2.0', value: 1 });
+                return null;
+            } catch (e) {
+                return e as StateError;
+            }
+        })();
+        expect(thrown).toBeInstanceOf(StateError);
+        expect(thrown?.message).toContain('Invalid Fake state');
+        expect(thrown?.component).toBe('Fake');
+        expect(thrown?.operation).toBe('load');
+        expect(c.applied).toBeNull();
+    });
+
+    it('migrates when the stored version differs, then applies the migrated state', () => {
+        const c = new FakeComponent();
+        c.loadState({ version: '1.0', value: 7 });
+        expect(c.migrateCalledWith).toEqual({ from: '1.0' });
+        expect(c.applied).toEqual({ version: '2.0', value: 999 });
+    });
+
+    it('skips validation when validate:false', () => {
+        const c = new FakeComponent();
+        c.valid = false; // would throw if validation ran
+        c.loadState({ version: '2.0', value: 5 }, { validate: false } as StateOptions);
+        expect(c.applied).toEqual({ version: '2.0', value: 5 });
+    });
+
+    it('skips migration when migrate:false even on a version mismatch', () => {
+        const c = new FakeComponent();
+        c.loadState({ version: '1.0', value: 5 }, { migrate: false } as StateOptions);
+        expect(c.migrateCalledWith).toBeNull();
+        expect(c.applied).toEqual({ version: '1.0', value: 5 });
+    });
+});
+
+describe('baseInspectable helper', () => {
+    const component = { id: 'x', type: 'X', name: 'thing' };
+
+    it('returns id/type/name and merges extra fields', () => {
+        const out: InspectableData = baseInspectable(component, { size: 10 });
+        expect(out).toMatchObject({ id: 'x', type: 'X', name: 'thing', size: 10 });
+        expect('address' in out).toBe(false);
+        expect('addressName' in out).toBe(false);
+    });
+
+    it('includes address metadata only when present on the component', () => {
+        const withAddr = { ...component } as WithBusMetadata<typeof component>;
+        withAddr.__address = '0xD010';
+        withAddr.__addressName = 'PIA';
+        const out = baseInspectable(withAddr);
+        expect(out.address).toBe('0xD010');
+        expect(out.addressName).toBe('PIA');
+    });
+
+    it('defaults name to empty string when undefined', () => {
+        const out = baseInspectable({ id: 'y', type: 'Y' });
+        expect(out.name).toBe('');
+    });
+});

--- a/src/core/base/inspectable.ts
+++ b/src/core/base/inspectable.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared helper for building the common head of an {@link InspectableData} object.
+ *
+ * RAM, ROM, Clock and PIA6820 all repeated the same id/type/name + optional
+ * `__address`/`__addressName` spread at the top of `getInspectable()`. This
+ * helper produces that head once; callers merge their component-specific
+ * `state`/`stats`/children and backward-compat flat fields via `extra`.
+ */
+import { InspectableBase, InspectableData, WithBusMetadata } from '../types';
+
+export function baseInspectable(component: InspectableBase, extra: Partial<InspectableData> = {}): InspectableData {
+    const self = component as WithBusMetadata<InspectableBase>;
+    return {
+        id: component.id,
+        type: component.type,
+        name: component.name ?? '',
+        ...(self.__address !== undefined && { address: self.__address }),
+        ...(self.__addressName !== undefined && { addressName: self.__addressName }),
+        ...extra,
+    };
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '4.48.0';
+export const APP_VERSION = '4.48.1';


### PR DESCRIPTION
## Context

Phase 1 of a multi-phase architecture cleanup focused on **reducing duplication** without changing emulation behavior.

`RAM`, `ROM`, `Clock`, `PIA6820`, and `Apple1` each independently hand-rolled the **identical** `loadState` preamble:

```
validate (optional) -> migrate if stored version differs -> apply
```

…and the **identical** `id`/`type`/`name` + optional `__address`/`__addressName` spread at the top of `getInspectable()`. The `IVersionedStatefulComponent` interface existed, but the *template* did not, so the sequence lived as five copies that could drift.

## Change

- **`src/core/base/VersionedStatefulComponentBase.ts`** — abstract generic implementing `loadState` as a [template method](https://en.wikipedia.org/wiki/Template_method_pattern): it fixes the invariant validate→migrate→apply sequence and defers only the variant `applyState(state, options)` to subclasses. Reuses the existing `StateManager.defaultStateOptions()` and `StateError`.
- **`src/core/base/inspectable.ts`** — `baseInspectable(component, extra)` builds the shared inspectable head once.
- The five components now `extends VersionedStatefulComponentBase<…>` and implement `applyState` (the body that used to follow the preamble). They keep their own `saveState`/`validateState`/`migrateState`/`resetState`.

## Verification

- `yarn test:ci` green: **713 passed, 19 skipped** (WASM-engine tests skip under Node, as before).
- New unit tests cover the template (validate-throws, version-mismatch-migrates, `validate:false`/`migrate:false` skips) and the inspectable helper.
- No behavior change — pure de-duplication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal state-management architecture for core emulated hardware components to enhance code maintainability and consistency.

* **Chores**
  * Bumped version to 4.48.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stid/Apple1JS/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->