### PR TITLE
refactor: extract EngineMetricsTracker shared by JS + WASM engines

### DIFF
--- a/src/core/cpu-engines/EngineMetricsTracker.ts
+++ b/src/core/cpu-engines/EngineMetricsTracker.ts
@@ -1,0 +1,163 @@
+/**
+ * Shared performance-metrics bookkeeping for CPU engines.
+ *
+ * JSEngine and WasmEngine carried byte-identical metrics machinery: the same
+ * fields (`hostExecMs`, `lastSecond*`, `metricsStartTime`), the same
+ * `initializeMetrics`/`updateMetrics`/`updateIPSMetrics` math, and the same
+ * `getMetrics` tail (instantaneous `lastIPS` + `hostMillisPerSecond`). This
+ * class owns that logic once so the metric semantics — notably
+ * `hostMillisPerSecond`, the real engine-cost signal the throttled in-app IPS
+ * hides — are defined in a single place. Engines *compose* a tracker rather
+ * than inherit, since each already implements `ICPUEngine`.
+ */
+import type { EngineMetrics } from '../cpu-interface/ICPUEngine';
+
+// Update the average-IPS window at most this often (ms).
+const IPS_UPDATE_INTERVAL_MS = 100;
+// Length of the instantaneous-IPS window (ms).
+const IPS_SECOND_WINDOW_MS = 1000;
+// Periodic memory-usage refresh cadence (every N instructions).
+const MEMORY_REFRESH_EVERY = 1000;
+// 6502 reference clock used to convert cycles -> emulated seconds.
+const CYCLES_PER_EMULATED_SECOND = 1_000_000;
+
+export class EngineMetricsTracker {
+    private metrics: EngineMetrics;
+    private metricsStartTime = Date.now();
+    private lastMetricsUpdate = Date.now();
+    private lastSecondInstructions = 0;
+    private lastSecondStartTime = Date.now();
+    // Cumulative host wall-clock ms spent in bulk execution since the last
+    // reset. Divided by emulated seconds in snapshot() to expose real cost.
+    private hostExecMs = 0;
+
+    /**
+     * @param efficiency Engine baseline efficiency (JS = 100, WASM = 500).
+     * @param getMemoryUsage Optional provider polled periodically for memoryUsage.
+     */
+    constructor(
+        private readonly efficiency: number,
+        private readonly getMemoryUsage?: () => number,
+    ) {
+        this.metrics = this.initializeMetrics();
+    }
+
+    private initializeMetrics(): EngineMetrics {
+        return {
+            totalCycles: 0,
+            instructionsExecuted: 0,
+            averageIPS: 0,
+            memoryUsage: 0,
+            lastStepDuration: 0,
+            initializationTime: 0,
+            efficiency: this.efficiency,
+        };
+    }
+
+    /** Record a single instruction step. `durationMs` is a wall-clock delta. */
+    recordStep(cycles: number, durationMs: number): void {
+        this.metrics.totalCycles += cycles;
+        this.metrics.instructionsExecuted++;
+        this.lastSecondInstructions++;
+        this.metrics.lastStepDuration = durationMs * 1_000_000; // ns
+        this.updateIPSMetrics();
+
+        if (this.getMemoryUsage && this.metrics.instructionsExecuted % MEMORY_REFRESH_EVERY === 0) {
+            this.metrics.memoryUsage = this.getMemoryUsage();
+        }
+    }
+
+    /**
+     * Record a bulk batch of `instructions` instructions over `cycles` cycles.
+     * Unlike single steps, bulk host time accrues into the host-cost metric.
+     */
+    recordBulk(cycles: number, durationMs: number, instructions: number): void {
+        this.hostExecMs += durationMs;
+        this.metrics.totalCycles += cycles;
+        this.metrics.lastStepDuration = durationMs * 1_000_000; // ns
+        this.metrics.instructionsExecuted += instructions;
+        this.lastSecondInstructions += instructions;
+        this.updateIPSMetrics();
+    }
+
+    /**
+     * Overwrite cumulative counts from an authoritative source (e.g. the WASM
+     * system's own `get_metrics()`), keeping wall-clock IPS computed here.
+     */
+    setCounts(counts: { totalCycles?: number; instructionsExecuted?: number }): void {
+        if (counts.totalCycles !== undefined) this.metrics.totalCycles = counts.totalCycles;
+        if (counts.instructionsExecuted !== undefined) {
+            this.metrics.instructionsExecuted = counts.instructionsExecuted;
+        }
+    }
+
+    setInitializationTime(ms: number): void {
+        this.metrics.initializationTime = ms;
+    }
+
+    get totalCycles(): number {
+        return this.metrics.totalCycles;
+    }
+
+    /** Live internal metrics object, for engine debug payloads. */
+    raw(): EngineMetrics {
+        return this.metrics;
+    }
+
+    /** Snapshot with computed instantaneous IPS and host cost, for getMetrics(). */
+    snapshot(): EngineMetrics {
+        this.updateIPSMetrics();
+
+        const now = Date.now();
+        const timeSinceSecondStart = now - this.lastSecondStartTime;
+        let lastIPS = 0;
+        if (timeSinceSecondStart > 0) {
+            lastIPS = Math.floor((this.lastSecondInstructions / timeSinceSecondStart) * 1000);
+        }
+
+        return {
+            ...this.metrics,
+            lastIPS: lastIPS || this.metrics.averageIPS,
+            // Host wall-clock ms per emulated second (1MHz => totalCycles/1e6 s).
+            hostMillisPerSecond: this.computeHostMillisPerSecond(),
+        } as EngineMetrics;
+    }
+
+    reset(): void {
+        this.metrics = this.initializeMetrics();
+        this.metricsStartTime = Date.now();
+        this.lastMetricsUpdate = Date.now();
+        this.lastSecondInstructions = 0;
+        this.lastSecondStartTime = Date.now();
+        this.hostExecMs = 0;
+    }
+
+    private computeHostMillisPerSecond(): number {
+        const emulatedSeconds = this.metrics.totalCycles / CYCLES_PER_EMULATED_SECOND;
+        return emulatedSeconds > 0 ? this.hostExecMs / emulatedSeconds : 0;
+    }
+
+    private updateIPSMetrics(): void {
+        const now = Date.now();
+        const timeSinceLastUpdate = now - this.lastMetricsUpdate;
+
+        // Update IPS every 100ms minimum OR when explicitly requested (delta 0).
+        if (timeSinceLastUpdate >= IPS_UPDATE_INTERVAL_MS || timeSinceLastUpdate === 0) {
+            const totalTime = now - this.metricsStartTime;
+            if (totalTime > 0 && this.metrics.instructionsExecuted > 0) {
+                this.metrics.averageIPS = Math.floor((this.metrics.instructionsExecuted / totalTime) * 1000);
+            }
+
+            // Roll the instantaneous-IPS window once per second.
+            const timeSinceSecondStart = now - this.lastSecondStartTime;
+            if (timeSinceSecondStart >= IPS_SECOND_WINDOW_MS) {
+                this.lastSecondInstructions = 0;
+                this.lastSecondStartTime = now;
+            }
+
+            if (timeSinceLastUpdate > 0) {
+                this.lastMetricsUpdate = now;
+            }
+        }
+    }
+}

--- a/src/core/cpu-engines/JSEngine.ts
+++ b/src/core/cpu-engines/JSEngine.ts
@@ -9,6 +9,7 @@ import type { ICPUEngine, EngineType, CPURegisters, EngineMetrics } from '../cpu
 import type { CPU6502State } from '../cpu6502/types';
 import type Bus from '../Bus';
 import CPU6502 from '../cpu6502/core';
+import { EngineMetricsTracker } from './EngineMetricsTracker';
 import { loggingService } from '../../services/LoggingService';
 
 /**
@@ -32,34 +33,11 @@ export class JSEngine implements ICPUEngine {
     // Set while performing a deliberate single step so the breakpoint on the
     // current PC is ignored — this is how the debugger steps *off* a breakpoint.
     private isSingleStepping = false;
-    private metrics: EngineMetrics;
-    private metricsStartTime: number;
-    private lastMetricsUpdate: number;
-    private lastSecondInstructions: number;
-    private lastSecondStartTime: number;
-    // Cumulative host wall-clock ms spent executing since the last reset.
-    // Divided by emulated seconds in getMetrics() to expose real engine cost.
-    private hostExecMs = 0;
+    // JS baseline efficiency is 100; bus + CPU + breakpoint memory estimate.
+    private metricsTracker = new EngineMetricsTracker(100, () => this.getMemoryUsage());
 
     constructor(private bus: Bus) {
         this.cpu = new CPU6502(bus);
-        this.metricsStartTime = Date.now();
-        this.lastMetricsUpdate = Date.now();
-        this.lastSecondInstructions = 0;
-        this.lastSecondStartTime = Date.now();
-        this.metrics = this.initializeMetrics();
-    }
-
-    private initializeMetrics(): EngineMetrics {
-        return {
-            totalCycles: 0,
-            instructionsExecuted: 0,
-            averageIPS: 0,
-            memoryUsage: 0,
-            lastStepDuration: 0,
-            initializationTime: 0,
-            efficiency: 100, // JS baseline
-        };
     }
 
     // ============ Initialization ============
@@ -88,7 +66,7 @@ export class JSEngine implements ICPUEngine {
 
         // Update metrics
         const duration = Date.now() - startTime;
-        this.updateMetrics(cycles, duration);
+        this.metricsTracker.recordStep(cycles, duration);
 
         return cycles;
     }
@@ -100,27 +78,15 @@ export class JSEngine implements ICPUEngine {
         const startTime = performance.now();
         this.cpu.performBulkSteps(cycles);
         const duration = performance.now() - startTime;
-        this.hostExecMs += duration;
-        this.metrics.totalCycles += cycles;
-        this.metrics.lastStepDuration = duration * 1_000_000; // Convert to nanoseconds
 
         // Estimate instructions executed (approximate - assume average 3 cycles per instruction)
         const estimatedInstructions = Math.floor(cycles / 3);
-        this.metrics.instructionsExecuted += estimatedInstructions;
-        this.lastSecondInstructions += estimatedInstructions;
-
-        // Update IPS calculation
-        this.updateIPSMetrics();
+        this.metricsTracker.recordBulk(cycles, duration, estimatedInstructions);
     }
 
     reset(): void {
         this.cpu.reset();
-        this.metrics = this.initializeMetrics();
-        this.metricsStartTime = Date.now();
-        this.lastMetricsUpdate = Date.now();
-        this.lastSecondInstructions = 0;
-        this.lastSecondStartTime = Date.now();
-        this.hostExecMs = 0;
+        this.metricsTracker.reset();
     }
 
     halt(): void {
@@ -270,43 +236,11 @@ export class JSEngine implements ICPUEngine {
     // ============ Performance & Metrics ============
 
     getMetrics(): EngineMetrics {
-        // Force update IPS calculation when metrics are requested
-        this.updateIPSMetrics();
-
-        // Calculate instantaneous IPS (last second)
-        const now = Date.now();
-        const timeSinceSecondStart = now - this.lastSecondStartTime;
-        let lastIPS = 0;
-        if (timeSinceSecondStart > 0) {
-            // Calculate IPS based on instructions in the current second window
-            lastIPS = Math.floor((this.lastSecondInstructions / timeSinceSecondStart) * 1000);
-        }
-
-        return {
-            ...this.metrics,
-            // Add lastIPS as a computed field
-            lastIPS: lastIPS || this.metrics.averageIPS,
-            // Host wall-clock ms per emulated second (1MHz => totalCycles/1e6 s)
-            hostMillisPerSecond: this.computeHostMillisPerSecond(),
-        } as EngineMetrics;
-    }
-
-    /**
-     * Host wall-clock milliseconds spent executing per second of emulated
-     * 6502 time. Exposes the real engine cost the throttled IPS hides.
-     */
-    private computeHostMillisPerSecond(): number {
-        const emulatedSeconds = this.metrics.totalCycles / 1_000_000;
-        return emulatedSeconds > 0 ? this.hostExecMs / emulatedSeconds : 0;
+        return this.metricsTracker.snapshot();
     }
 
     resetMetrics(): void {
-        this.metrics = this.initializeMetrics();
-        this.metricsStartTime = Date.now();
-        this.lastMetricsUpdate = Date.now();
-        this.lastSecondInstructions = 0;
-        this.lastSecondStartTime = Date.now();
-        this.hostExecMs = 0;
+        this.metricsTracker.reset();
     }
 
     setProfiling(enabled: boolean): void {
@@ -334,56 +268,13 @@ export class JSEngine implements ICPUEngine {
         return 65536 + 1024 + this.breakpoints.size * 8;
     }
 
-    // ============ Private Methods ============
-
-    private updateMetrics(cycles: number, duration: number): void {
-        this.metrics.totalCycles += cycles;
-        this.metrics.instructionsExecuted++;
-        this.lastSecondInstructions++;
-        this.metrics.lastStepDuration = duration * 1_000_000; // Convert to nanoseconds
-
-        // Update IPS calculation
-        this.updateIPSMetrics();
-
-        // Update memory usage periodically
-        if (this.metrics.instructionsExecuted % 1000 === 0) {
-            this.metrics.memoryUsage = this.getMemoryUsage();
-        }
-    }
-
-    private updateIPSMetrics(): void {
-        const now = Date.now();
-        const timeSinceLastUpdate = now - this.lastMetricsUpdate;
-
-        // Update IPS every 100ms minimum OR when explicitly requested
-        if (timeSinceLastUpdate >= 100 || timeSinceLastUpdate === 0) {
-            // Calculate average IPS over entire runtime
-            const totalTime = now - this.metricsStartTime;
-            if (totalTime > 0 && this.metrics.instructionsExecuted > 0) {
-                this.metrics.averageIPS = Math.floor((this.metrics.instructionsExecuted / totalTime) * 1000);
-            }
-
-            // Reset last second counter every second for instantaneous IPS
-            const timeSinceSecondStart = now - this.lastSecondStartTime;
-            if (timeSinceSecondStart >= 1000) {
-                this.lastSecondInstructions = 0;
-                this.lastSecondStartTime = now;
-            }
-
-            // Only update lastMetricsUpdate if time has actually passed
-            if (timeSinceLastUpdate > 0) {
-                this.lastMetricsUpdate = now;
-            }
-        }
-    }
-
     // ============ Engine-Specific Features ============
 
     getDebugInfo(): unknown {
         return {
             cpu: this.cpu.getInspectable(),
             breakpoints: Array.from(this.breakpoints),
-            metrics: this.metrics,
+            metrics: this.metricsTracker.raw(),
         };
     }
 

--- a/src/core/cpu-engines/WasmEngine.ts
+++ b/src/core/cpu-engines/WasmEngine.ts
@@ -13,6 +13,7 @@ import type { CPU6502State } from '../cpu6502/types';
 import type { WasmSystem } from './wasm-loader';
 import type Bus from '../Bus';
 import { initializeWasmModule, getWasmSystemClass, isWasmSupported } from './wasm-loader';
+import { EngineMetricsTracker } from './EngineMetricsTracker';
 import { installMemoryBridge, setBusForWasm } from './wasm-memory-bridge';
 import { loggingService } from '../../services/LoggingService';
 import { Formatters } from '../../utils/formatters';
@@ -37,24 +38,13 @@ export class WasmEngine implements ICPUEngine {
     private bus: Bus; // Keep for I/O synchronization
     private breakpoints = new Set<number>();
     private breakpointListeners = new Set<(address: number) => void>();
-    private metrics: EngineMetrics;
-    private metricsStartTime: number;
-    private lastMetricsUpdate: number;
-    private lastSecondInstructions: number;
-    private lastSecondStartTime: number;
+    // WasmSystem efficiency baseline 500 (5x JS, no boundary crossings).
+    private metricsTracker = new EngineMetricsTracker(500, () => this.getMemoryUsage());
     private initPromise: Promise<void> | null = null;
     private _isReady = false;
-    // Cumulative host wall-clock ms spent executing since the last reset.
-    // Divided by emulated seconds in getMetrics() to expose real engine cost.
-    private hostExecMs = 0;
 
     constructor(bus: Bus) {
         this.bus = bus;
-        this.metricsStartTime = Date.now();
-        this.lastMetricsUpdate = Date.now();
-        this.lastSecondInstructions = 0;
-        this.lastSecondStartTime = Date.now();
-        this.metrics = this.initializeMetrics();
 
         // Check WASM support
         if (!isWasmSupported()) {
@@ -66,18 +56,6 @@ export class WasmEngine implements ICPUEngine {
 
     get isReady(): boolean {
         return this._isReady;
-    }
-
-    private initializeMetrics(): EngineMetrics {
-        return {
-            totalCycles: 0,
-            instructionsExecuted: 0,
-            averageIPS: 0,
-            memoryUsage: 0,
-            lastStepDuration: 0,
-            initializationTime: 0,
-            efficiency: 500, // WasmSystem is 5x more efficient (no boundary crossings)
-        };
     }
 
     // ============ Initialization ============
@@ -204,12 +182,10 @@ export class WasmEngine implements ICPUEngine {
             this.seedRamFromBus();
 
             this._isReady = true;
-            this.metrics.initializationTime = Date.now() - startTime;
+            const initializationTime = Date.now() - startTime;
+            this.metricsTracker.setInitializationTime(initializationTime);
 
-            loggingService.info(
-                'WasmEngine',
-                `WASM System initialized in ${this.metrics.initializationTime.toFixed(2)}ms`,
-            );
+            loggingService.info('WasmEngine', `WASM System initialized in ${initializationTime.toFixed(2)}ms`);
         } catch (error) {
             loggingService.error('WasmEngine', `Failed to initialize WASM engine: ${error}`);
             throw new Error(`WASM engine initialization failed: ${error}`);
@@ -296,7 +272,7 @@ export class WasmEngine implements ICPUEngine {
 
         // Update metrics
         const duration = Date.now() - startTime;
-        this.updateMetrics(cycles, duration);
+        this.metricsTracker.recordStep(cycles, duration);
 
         return cycles;
     }
@@ -311,7 +287,7 @@ export class WasmEngine implements ICPUEngine {
         // Time the call with performance.now() (sub-ms) for the host-utilization metric.
         const startTime = performance.now();
         const executedCycles = this.wasmSystem.run_cycles(cycles);
-        this.hostExecMs += performance.now() - startTime;
+        const duration = performance.now() - startTime;
 
         // Check if a breakpoint was hit during bulk execution. Rust halts before
         // executing the instruction at the breakpoint, leaving the PC parked on
@@ -333,16 +309,11 @@ export class WasmEngine implements ICPUEngine {
 
         // Note: I/O happens automatically via memory bridge - no sync needed
 
-        // Update metrics for the whole batch. NOTE: updateMetrics() increments
-        // the instruction counter by one and is only correct for single steps;
-        // a bulk batch runs many instructions, so account for them here the same
-        // way JSEngine does (estimate from cycles) to keep IPS comparable.
+        // Account for the whole batch with an estimated instruction count
+        // (cycles/3, same as JSEngine) so IPS stays comparable across engines.
         if (executedCycles > 0) {
             const estimatedInstructions = Math.floor(executedCycles / 3);
-            this.metrics.totalCycles += executedCycles;
-            this.metrics.instructionsExecuted += estimatedInstructions;
-            this.lastSecondInstructions += estimatedInstructions;
-            this.updateIPSMetrics();
+            this.metricsTracker.recordBulk(executedCycles, duration, estimatedInstructions);
         }
     }
 
@@ -355,12 +326,7 @@ export class WasmEngine implements ICPUEngine {
         // Reset the WASM System
         this.wasmSystem.reset();
 
-        this.metrics = this.initializeMetrics();
-        this.metricsStartTime = Date.now();
-        this.lastMetricsUpdate = Date.now();
-        this.lastSecondInstructions = 0;
-        this.lastSecondStartTime = Date.now();
-        this.hostExecMs = 0;
+        this.metricsTracker.reset();
     }
 
     halt(): void {
@@ -392,7 +358,7 @@ export class WasmEngine implements ICPUEngine {
         const status = wasmState.status;
         const irq = wasmState.irq;
         const nmi = wasmState.nmi;
-        const cycles = wasmState.cycles || this.metrics.totalCycles;
+        const cycles = wasmState.cycles || this.metricsTracker.totalCycles;
 
         // Return new object (wasmState reference is now released)
         return {
@@ -634,57 +600,24 @@ export class WasmEngine implements ICPUEngine {
 
     getMetrics(): EngineMetrics {
         if (this.wasmSystem) {
-            // Get metrics from WasmSystem if available
+            // Get cumulative counts from WasmSystem if available. averageIPS and
+            // hostMillisPerSecond stay computed by the tracker (wall-clock), NOT
+            // taken from the Rust get_metrics() idealized instructions-per-1MHz
+            // figure, so the two engines remain directly comparable.
             const wasmMetrics = this.wasmSystem.get_metrics();
             if (wasmMetrics) {
-                this.metrics.totalCycles = wasmMetrics.cycles || this.metrics.totalCycles;
-                this.metrics.instructionsExecuted = wasmMetrics.instructions || this.metrics.instructionsExecuted;
-                // averageIPS is intentionally NOT taken from wasmMetrics: the Rust
-                // get_metrics() reports (instructions/cycles)*1e6 (an idealized
-                // instructions-per-1MHz figure), not wall-clock IPS. updateIPSMetrics()
-                // below computes a real wall-clock rate from instructionsExecuted,
-                // matching JSEngine so the two engines are comparable.
+                this.metricsTracker.setCounts({
+                    totalCycles: wasmMetrics.cycles || undefined,
+                    instructionsExecuted: wasmMetrics.instructions || undefined,
+                });
             }
         }
 
-        // Force update IPS calculation when metrics are requested (consistent with JSEngine)
-        this.updateIPSMetrics();
-
-        // Calculate instantaneous IPS (last second)
-        const now = Date.now();
-        const timeSinceSecondStart = now - this.lastSecondStartTime;
-        let lastIPS = 0;
-        if (timeSinceSecondStart > 0) {
-            // Calculate IPS based on instructions in the current second window
-            lastIPS = Math.floor((this.lastSecondInstructions / timeSinceSecondStart) * 1000);
-        }
-
-        return {
-            ...this.metrics,
-            // Add lastIPS as a computed field
-            lastIPS: lastIPS || this.metrics.averageIPS,
-            // Host wall-clock ms per emulated second (1MHz => totalCycles/1e6 s)
-            hostMillisPerSecond: this.computeHostMillisPerSecond(),
-        } as EngineMetrics;
-    }
-
-    /**
-     * Host wall-clock milliseconds spent executing per second of emulated
-     * 6502 time. Mirrors JSEngine so the two engines are directly comparable;
-     * this is where WASM's real advantage shows (far fewer host ms per second).
-     */
-    private computeHostMillisPerSecond(): number {
-        const emulatedSeconds = this.metrics.totalCycles / 1_000_000;
-        return emulatedSeconds > 0 ? this.hostExecMs / emulatedSeconds : 0;
+        return this.metricsTracker.snapshot();
     }
 
     resetMetrics(): void {
-        this.metrics = this.initializeMetrics();
-        this.metricsStartTime = Date.now();
-        this.lastMetricsUpdate = Date.now();
-        this.lastSecondInstructions = 0;
-        this.lastSecondStartTime = Date.now();
-        this.hostExecMs = 0;
+        this.metricsTracker.reset();
     }
 
     getMemoryUsage(): number {
@@ -775,51 +708,6 @@ export class WasmEngine implements ICPUEngine {
 
     // ============ Private Methods ============
 
-    private updateMetrics(cycles: number, duration: number): void {
-        this.metrics.totalCycles += cycles;
-        this.metrics.instructionsExecuted++;
-        this.lastSecondInstructions++;
-        this.metrics.lastStepDuration = duration * 1_000_000; // Convert to nanoseconds
-
-        // Update IPS calculation (same algorithm as JSEngine for consistency)
-        this.updateIPSMetrics();
-
-        // Update memory usage periodically
-        if (this.metrics.instructionsExecuted % 1000 === 0) {
-            this.metrics.memoryUsage = this.getMemoryUsage();
-        }
-    }
-
-    /**
-     * Update IPS metrics with consistent algorithm (matches JSEngine)
-     * Uses 100ms minimum update interval and 1-second rolling window for lastIPS
-     */
-    private updateIPSMetrics(): void {
-        const now = Date.now();
-        const timeSinceLastUpdate = now - this.lastMetricsUpdate;
-
-        // Update IPS every 100ms minimum OR when explicitly requested (timeSinceLastUpdate === 0)
-        if (timeSinceLastUpdate >= 100 || timeSinceLastUpdate === 0) {
-            // Calculate average IPS over entire runtime
-            const totalTime = now - this.metricsStartTime;
-            if (totalTime > 0 && this.metrics.instructionsExecuted > 0) {
-                this.metrics.averageIPS = Math.floor((this.metrics.instructionsExecuted / totalTime) * 1000);
-            }
-
-            // Reset last second counter every second for instantaneous IPS
-            const timeSinceSecondStart = now - this.lastSecondStartTime;
-            if (timeSinceSecondStart >= 1000) {
-                this.lastSecondInstructions = 0;
-                this.lastSecondStartTime = now;
-            }
-
-            // Only update lastMetricsUpdate if time has actually passed
-            if (timeSinceLastUpdate > 0) {
-                this.lastMetricsUpdate = now;
-            }
-        }
-    }
-
     // ============ Engine-Specific Features ============
 
     getDebugInfo(): unknown {
@@ -827,7 +715,7 @@ export class WasmEngine implements ICPUEngine {
             return {
                 status: 'Not initialized',
                 breakpoints: Array.from(this.breakpoints),
-                metrics: this.metrics,
+                metrics: this.metricsTracker.raw(),
             };
         }
 
@@ -836,7 +724,7 @@ export class WasmEngine implements ICPUEngine {
             engineVersion: this.engineVersion,
             registers: this.getRegisters(),
             breakpoints: Array.from(this.breakpoints),
-            metrics: this.metrics,
+            metrics: this.metricsTracker.raw(),
             wasmMetrics: this.wasmSystem.get_metrics(),
             memoryMap: this.wasmSystem.get_memory_map(),
         };
@@ -860,7 +748,7 @@ export class WasmEngine implements ICPUEngine {
         const y = state.y;
         const s = state.s;
         const status = state.status;
-        const cycles = state.cycles ?? this.metrics.totalCycles;
+        const cycles = state.cycles ?? this.metricsTracker.totalCycles;
         const irq = state.irq;
         const nmi = state.nmi;
 

--- a/src/core/cpu-engines/__tests__/EngineMetricsTracker-counters.vitest.test.ts
+++ b/src/core/cpu-engines/__tests__/EngineMetricsTracker-counters.vitest.test.ts
@@ -1,0 +1,71 @@
+import { EngineMetricsTracker } from '../EngineMetricsTracker';
+
+describe('EngineMetricsTracker', () => {
+    it('carries the engine efficiency baseline into snapshots', () => {
+        expect(new EngineMetricsTracker(100).snapshot().efficiency).toBe(100);
+        expect(new EngineMetricsTracker(500).snapshot().efficiency).toBe(500);
+    });
+
+    it('accumulates cycles and instructions across single steps', () => {
+        const t = new EngineMetricsTracker(100);
+        t.recordStep(2, 0);
+        t.recordStep(3, 0);
+        const m = t.snapshot();
+        expect(m.totalCycles).toBe(5);
+        expect(m.instructionsExecuted).toBe(2);
+    });
+
+    it('accumulates a bulk batch by explicit instruction count', () => {
+        const t = new EngineMetricsTracker(100);
+        t.recordBulk(300, 0, 100);
+        const m = t.snapshot();
+        expect(m.totalCycles).toBe(300);
+        expect(m.instructionsExecuted).toBe(100);
+    });
+
+    it('derives host ms per emulated second from bulk host time', () => {
+        const t = new EngineMetricsTracker(100);
+        // 1,000,000 cycles at 1MHz == 1 emulated second; 50ms host time => 50 ms/s.
+        t.recordBulk(1_000_000, 50, 333_333);
+        expect(t.snapshot().hostMillisPerSecond).toBeCloseTo(50, 5);
+    });
+
+    it('reports zero host ms per second before any bulk execution', () => {
+        const t = new EngineMetricsTracker(100);
+        t.recordStep(5, 0); // single steps do not accrue host exec time
+        expect(t.snapshot().hostMillisPerSecond).toBe(0);
+    });
+
+    it('lets an authoritative source override cumulative counts', () => {
+        const t = new EngineMetricsTracker(500);
+        t.recordBulk(10, 1, 3);
+        t.setCounts({ totalCycles: 9999, instructionsExecuted: 1234 });
+        const m = t.snapshot();
+        expect(m.totalCycles).toBe(9999);
+        expect(m.instructionsExecuted).toBe(1234);
+    });
+
+    it('records last step duration in nanoseconds', () => {
+        const t = new EngineMetricsTracker(100);
+        t.recordStep(2, 2); // 2ms
+        expect(t.snapshot().lastStepDuration).toBe(2_000_000);
+    });
+
+    it('reset() returns all counters to their initial values', () => {
+        const t = new EngineMetricsTracker(100);
+        t.recordBulk(1_000_000, 50, 100);
+        t.reset();
+        const m = t.snapshot();
+        expect(m.totalCycles).toBe(0);
+        expect(m.instructionsExecuted).toBe(0);
+        expect(m.hostMillisPerSecond).toBe(0);
+        expect(m.efficiency).toBe(100);
+    });
+
+    it('exposes the live metrics object and total cycles for debug payloads', () => {
+        const t = new EngineMetricsTracker(100);
+        t.recordStep(7, 0);
+        expect(t.totalCycles).toBe(7);
+        expect(t.raw().totalCycles).toBe(7);
+    });
+});

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '4.48.1';
+export const APP_VERSION = '4.48.2';


### PR DESCRIPTION
## Context

Phase 2 of the architecture cleanup (duplication-reduction lens). **Stacked on #169** (`fix/state-base`) — review/merge that first.

`JSEngine` and `WasmEngine` carried **byte-identical** performance-metrics machinery:
- identical fields: `hostExecMs`, `lastSecondInstructions`, `lastSecondStartTime`, `metricsStartTime`, `lastMetricsUpdate`
- identical `initializeMetrics` / `updateMetrics` / `updateIPSMetrics` math
- identical `getMetrics` tail computing instantaneous `lastIPS` and `hostMillisPerSecond` (the real engine-cost signal the throttled in-app IPS hides)

## Change

- **`src/core/cpu-engines/EngineMetricsTracker.ts`** — owns the counters and the IPS / host-cost math once. API: `recordStep(cycles, ms)`, `recordBulk(cycles, ms, instructions)`, `setCounts(...)` (for WASM's authoritative cumulative counts), `snapshot()`, `reset()`, `raw()`, `totalCycles`.
- Both engines **compose** a tracker (no inheritance — they already implement `ICPUEngine`) with their efficiency baseline (JS 100, WASM 500) and `getMemoryUsage` provider.
- Consistency fix: WASM's bulk path now also records `lastStepDuration`, and host-time accrual is gated on `executedCycles > 0` (a zero-cycle bulk = breakpoint hit = no emulated work, so it shouldn't accrue host cost). Both engines now share identical metric semantics.

`WasmSystemEngine` (the unused duplicate engine) is intentionally left for the Phase 5 WASM cleanup, which removes it entirely.

## Verification

- `yarn test:ci` green: **722 passed, 19 skipped** (+9 new `EngineMetricsTracker` unit tests covering counters, host-ms-per-second math, `setCounts` override, reset).
- Execution behavior unchanged — this is metrics bookkeeping only. (WASM metrics display is best confirmed in a browser; the change is execution-neutral.)
- Net: ~200 lines of duplicated machinery across the two engines replaced by one shared 163-line tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved CPU engine performance metrics tracking with centralized measurement and more reliable efficiency calculations.

* **Tests**
  * Added comprehensive test coverage for metrics tracking validation.

* **Chores**
  * Version bumped to 4.48.2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stid/Apple1JS/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->