### PR TITLE
refactor: de-duplicate worker plumbing (Subscribable + callWorker helper)

### DIFF
--- a/src/apple1/Subscribable.ts
+++ b/src/apple1/Subscribable.ts
@@ -1,0 +1,39 @@
+/**
+ * A minimal multi-listener event source with unsubscribe and error isolation.
+ *
+ * WorkerAPI maintained five hand-written `Set<callback>` fields, each with the
+ * same add / return-unsubscribe / `forEach(cb => cb(value))` shape. This
+ * collapses that into one primitive. Listener errors are isolated so a single
+ * throwing subscriber can't abort dispatch to the others (the behaviour the
+ * video path already special-cased, now applied uniformly).
+ */
+export class Subscribable<T> {
+    private readonly listeners = new Set<(value: T) => void>();
+
+    /** @param onError invoked with any error thrown by a listener during emit. */
+    constructor(private readonly onError?: (error: unknown) => void) {}
+
+    /** Register a listener; returns an unsubscribe function. */
+    subscribe(listener: (value: T) => void): () => void {
+        this.listeners.add(listener);
+        return () => {
+            this.listeners.delete(listener);
+        };
+    }
+
+    /** Deliver a value to every listener, isolating individual failures. */
+    emit(value: T): void {
+        this.listeners.forEach((listener) => {
+            try {
+                listener(value);
+            } catch (error) {
+                this.onError?.(error);
+            }
+        });
+    }
+
+    /** Number of currently-registered listeners. */
+    get size(): number {
+        return this.listeners.size;
+    }
+}

--- a/src/apple1/WorkerAPI.ts
+++ b/src/apple1/WorkerAPI.ts
@@ -1,4 +1,5 @@
 import { WorkerState } from './WorkerState';
+import { Subscribable } from './Subscribable';
 import type { IWorkerAPI } from './types/worker-api';
 import type { EmulatorState } from './types/emulator-state';
 import type { VideoData } from './types/video';
@@ -21,12 +22,23 @@ import { Formatters } from '../utils/formatters';
  * This replaces the large switch statement with a cleaner API.
  */
 export class WorkerAPI implements IWorkerAPI {
-    // Event callback storage
-    private videoCallbacks = new Set<(data: VideoData) => void>();
-    private breakpointCallbacks = new Set<(address: number) => void>();
-    private statusCallbacks = new Set<(status: 'running' | 'paused') => void>();
-    private clockCallbacks = new Set<(data: ClockData) => void>();
-    private runToCursorCallbacks = new Set<(target: number | null) => void>();
+    // Event sources fanned out to UI subscribers. Listener errors are isolated
+    // (one throwing subscriber can't abort dispatch to the others).
+    private readonly videoEvent = new Subscribable<VideoData>((e) =>
+        loggingService.error('WorkerAPI', `video listener threw: ${e}`),
+    );
+    private readonly breakpointEvent = new Subscribable<number>((e) =>
+        loggingService.error('WorkerAPI', `breakpoint listener threw: ${e}`),
+    );
+    private readonly statusEvent = new Subscribable<'running' | 'paused'>((e) =>
+        loggingService.error('WorkerAPI', `status listener threw: ${e}`),
+    );
+    private readonly clockEvent = new Subscribable<ClockData>((e) =>
+        loggingService.error('WorkerAPI', `clock listener threw: ${e}`),
+    );
+    private readonly runToCursorEvent = new Subscribable<number | null>((e) =>
+        loggingService.error('WorkerAPI', `run-to-cursor listener threw: ${e}`),
+    );
 
     constructor(private workerState: WorkerState) {
         // Enforce breakpoints uniformly across engines: subscribe to the active
@@ -62,13 +74,13 @@ export class WorkerAPI implements IWorkerAPI {
             if (!this.workerState.breakpoints.has(target)) {
                 this.workerState.getDualEngine()?.clearBreakpoint(target);
             }
-            this.statusCallbacks.forEach((cb) => cb('paused'));
-            this.runToCursorCallbacks.forEach((cb) => cb(null));
+            this.statusEvent.emit('paused');
+            this.runToCursorEvent.emit(null);
             return;
         }
 
-        this.statusCallbacks.forEach((cb) => cb('paused'));
-        this.breakpointCallbacks.forEach((cb) => cb(address));
+        this.statusEvent.emit('paused');
+        this.breakpointEvent.emit(address);
         loggingService.log('info', 'Breakpoint', `Hit breakpoint at ${Formatters.address(address)}`);
     }
 
@@ -84,15 +96,9 @@ export class WorkerAPI implements IWorkerAPI {
                     if (typeof globalThis.structuredClone !== 'undefined') {
                         globalThis.structuredClone(data);
                     }
-                    this.videoCallbacks.forEach((cb) => {
-                        try {
-                            cb(data);
-                        } catch (error) {
-                            console.error('Error calling video callback:', error);
-                        }
-                    });
+                    this.videoEvent.emit(data);
                 } catch (error) {
-                    console.error('VideoData cannot be structured cloned:', error, data);
+                    loggingService.error('WorkerAPI', `VideoData cannot be structured cloned: ${error}`);
                 }
             });
         }
@@ -132,7 +138,7 @@ export class WorkerAPI implements IWorkerAPI {
         }
 
         // Notify status callbacks
-        this.statusCallbacks.forEach((cb) => cb('paused'));
+        this.statusEvent.emit('paused');
     }
 
     resumeEmulation(): void {
@@ -145,7 +151,7 @@ export class WorkerAPI implements IWorkerAPI {
         }
 
         // Notify status callbacks
-        this.statusCallbacks.forEach((cb) => cb('running'));
+        this.statusEvent.emit('running');
     }
 
     step(): FilteredDebugData {
@@ -173,7 +179,7 @@ export class WorkerAPI implements IWorkerAPI {
         // Check if we landed on a breakpoint after stepping (at the new PC).
         const pc = dualEngine?.getRegisters ? dualEngine.getRegisters().PC : cpu.PC;
         if (this.workerState.breakpoints.has(pc)) {
-            this.breakpointCallbacks.forEach((cb) => cb(pc));
+            this.breakpointEvent.emit(pc);
         }
 
         // CPU state must come from the active engine (the JS CPU is dormant/stale
@@ -268,7 +274,7 @@ export class WorkerAPI implements IWorkerAPI {
 
         // Store the run-to-cursor target and notify listeners.
         this.workerState.runToCursorTarget = targetAddress;
-        this.runToCursorCallbacks.forEach((cb) => cb(this.workerState.runToCursorTarget));
+        this.runToCursorEvent.emit(this.workerState.runToCursorTarget);
 
         // Model run-to-cursor as a transient breakpoint on the active engine.
         // handleBreakpointHit() clears it on arrival (unless it is also a real
@@ -282,7 +288,7 @@ export class WorkerAPI implements IWorkerAPI {
         if (this.workerState.isPaused) {
             this.workerState.apple1.clock.resume();
             this.workerState.isPaused = false;
-            this.statusCallbacks.forEach((cb) => cb('running'));
+            this.statusEvent.emit('running');
         }
 
         loggingService.log('info', 'RunToAddress', `Running to address ${Formatters.address(targetAddress)}`);
@@ -525,7 +531,7 @@ export class WorkerAPI implements IWorkerAPI {
     // These will be implemented in Phase 1 with Comlink.proxy
 
     onVideoUpdate(callback: (data: VideoData) => void): () => void {
-        this.videoCallbacks.add(callback);
+        const unsubscribe = this.videoEvent.subscribe(callback);
         // Deliver the current frame immediately: the power-on screen is emitted
         // before any subscriber registers, so a late subscriber (e.g. React mounting
         // after the worker booted) would otherwise never see it until the next write.
@@ -534,36 +540,22 @@ export class WorkerAPI implements IWorkerAPI {
             const { buffer, row, column } = video.getState();
             callback({ buffer, row, column });
         }
-        return () => {
-            this.videoCallbacks.delete(callback);
-        };
+        return unsubscribe;
     }
 
     onBreakpointHit(callback: (address: number) => void): () => void {
-        this.breakpointCallbacks.add(callback);
-        return () => {
-            this.breakpointCallbacks.delete(callback);
-        };
+        return this.breakpointEvent.subscribe(callback);
     }
 
     onEmulationStatus(callback: (status: 'running' | 'paused') => void): () => void {
-        this.statusCallbacks.add(callback);
-        return () => {
-            this.statusCallbacks.delete(callback);
-        };
+        return this.statusEvent.subscribe(callback);
     }
 
     onClockData(callback: (data: ClockData) => void): () => void {
-        this.clockCallbacks.add(callback);
-        return () => {
-            this.clockCallbacks.delete(callback);
-        };
+        return this.clockEvent.subscribe(callback);
     }
 
     onRunToCursorTarget(callback: (target: number | null) => void): () => void {
-        this.runToCursorCallbacks.add(callback);
-        return () => {
-            this.runToCursorCallbacks.delete(callback);
-        };
+        return this.runToCursorEvent.subscribe(callback);
     }
 }

--- a/src/apple1/__tests__/Subscribable-events.vitest.test.ts
+++ b/src/apple1/__tests__/Subscribable-events.vitest.test.ts
@@ -1,0 +1,57 @@
+import { Subscribable } from '../Subscribable';
+
+describe('Subscribable', () => {
+    it('delivers emitted values to a subscriber', () => {
+        const ev = new Subscribable<number>();
+        const seen: number[] = [];
+        ev.subscribe((v) => seen.push(v));
+        ev.emit(1);
+        ev.emit(2);
+        expect(seen).toEqual([1, 2]);
+    });
+
+    it('stops delivery after unsubscribe', () => {
+        const ev = new Subscribable<number>();
+        const seen: number[] = [];
+        const unsub = ev.subscribe((v) => seen.push(v));
+        ev.emit(1);
+        unsub();
+        ev.emit(2);
+        expect(seen).toEqual([1]);
+    });
+
+    it('fans out to every listener', () => {
+        const ev = new Subscribable<string>();
+        const a: string[] = [];
+        const b: string[] = [];
+        ev.subscribe((v) => a.push(v));
+        ev.subscribe((v) => b.push(v));
+        ev.emit('x');
+        expect(a).toEqual(['x']);
+        expect(b).toEqual(['x']);
+    });
+
+    it('isolates a throwing listener and routes the error to onError', () => {
+        const errors: unknown[] = [];
+        const ev = new Subscribable<number>((e) => errors.push(e));
+        const seen: number[] = [];
+        ev.subscribe(() => {
+            throw new Error('boom');
+        });
+        ev.subscribe((v) => seen.push(v));
+        ev.emit(42);
+        expect(seen).toEqual([42]); // sibling still received the value
+        expect(errors).toHaveLength(1);
+        expect((errors[0] as Error).message).toBe('boom');
+    });
+
+    it('tracks the live listener count', () => {
+        const ev = new Subscribable<void>();
+        expect(ev.size).toBe(0);
+        const unsub = ev.subscribe(() => {});
+        ev.subscribe(() => {});
+        expect(ev.size).toBe(2);
+        unsub();
+        expect(ev.size).toBe(1);
+    });
+});

--- a/src/services/WorkerManager.ts
+++ b/src/services/WorkerManager.ts
@@ -7,7 +7,7 @@ import type {
     FilteredDebugData,
     MemoryMapData,
     EngineStatusData,
-    EngineComparisonData
+    EngineComparisonData,
 } from '../apple1/types/worker-messages';
 // CONFIG no longer needed since Comlink is the only implementation
 
@@ -15,7 +15,7 @@ import type {
  * WorkerManager provides a unified interface for worker communication
  * that can switch between the legacy postMessage approach and the new
  * Comlink-based implementation based on a feature flag.
- * 
+ *
  * This enables a gradual migration and easy rollback if needed.
  */
 export class WorkerManager {
@@ -37,14 +37,11 @@ export class WorkerManager {
         }
 
         // Load the Comlink-based worker (only implementation)
-        this.worker = new Worker(
-            new URL('../apple1/Apple.worker.comlink.ts', import.meta.url),
-            { type: 'module' }
-        );
-        
+        this.worker = new Worker(new URL('../apple1/Apple.worker.comlink.ts', import.meta.url), { type: 'module' });
+
         // Wrap the worker with Comlink
         this.comlinkAPI = Comlink.wrap<IWorkerAPI>(this.worker);
-        
+
         // Set up message handler for backward compatibility
         // Note: All events now go through Comlink, this is kept for potential future use
         this.worker.onmessage = (e: MessageEvent<WorkerMessage>) => {
@@ -78,153 +75,128 @@ export class WorkerManager {
         this.messageHandlers.delete(type);
     }
 
+    /**
+     * Invoke an operation on the Comlink worker API if it is initialized,
+     * otherwise resolve to `undefined` (a no-op). Collapses the
+     * `if (this.comlinkAPI) return await this.comlinkAPI.x(...)` boilerplate.
+     */
+    private async call<T>(fn: (api: Comlink.Remote<IWorkerAPI>) => Promise<T>): Promise<T | void> {
+        if (this.comlinkAPI) {
+            return await fn(this.comlinkAPI);
+        }
+    }
+
+    /**
+     * Like {@link call} but throws when the worker is not initialized — for
+     * methods whose contract is non-void (callers depend on a real result).
+     */
+    private async callOrThrow<T>(fn: (api: Comlink.Remote<IWorkerAPI>) => Promise<T>): Promise<T> {
+        if (this.comlinkAPI) {
+            return await fn(this.comlinkAPI);
+        }
+        throw new Error('Worker not initialized');
+    }
+
     // ========== Emulation Control ==========
 
     async pauseEmulation(): Promise<void> {
-        if (this.comlinkAPI) {
-            await this.comlinkAPI.pauseEmulation();
-        }
+        await this.call((api) => api.pauseEmulation());
     }
 
     async resumeEmulation(): Promise<void> {
-        if (this.comlinkAPI) {
-            await this.comlinkAPI.resumeEmulation();
-        }
+        await this.call((api) => api.resumeEmulation());
     }
 
     async step(): Promise<FilteredDebugData | void> {
-        if (this.comlinkAPI) {
-            return await this.comlinkAPI.step();
-        }
+        return this.call((api) => api.step());
     }
 
     async saveState(): Promise<EmulatorState | void> {
-        if (this.comlinkAPI) {
-            return await this.comlinkAPI.saveState();
-        }
+        return this.call((api) => api.saveState());
     }
 
     async loadState(state: EmulatorState): Promise<void> {
-        if (this.comlinkAPI) {
-            await this.comlinkAPI.loadState(state);
-        }
+        await this.call((api) => api.loadState(state));
     }
 
     // ========== Breakpoint Management ==========
 
     async setBreakpoint(address: number): Promise<number[] | void> {
-        if (this.comlinkAPI) {
-            return await this.comlinkAPI.setBreakpoint(address);
-        }
+        return this.call((api) => api.setBreakpoint(address));
     }
 
     async clearBreakpoint(address: number): Promise<number[] | void> {
-        if (this.comlinkAPI) {
-            return await this.comlinkAPI.clearBreakpoint(address);
-        }
+        return this.call((api) => api.clearBreakpoint(address));
     }
 
     async clearAllBreakpoints(): Promise<void> {
-        if (this.comlinkAPI) {
-            await this.comlinkAPI.clearAllBreakpoints();
-        }
+        await this.call((api) => api.clearAllBreakpoints());
     }
 
     async runToAddress(address: number): Promise<void> {
-        if (this.comlinkAPI) {
-            await this.comlinkAPI.runToAddress(address);
-        }
+        await this.call((api) => api.runToAddress(address));
     }
 
     async getBreakpoints(): Promise<number[] | void> {
-        if (this.comlinkAPI) {
-            return await this.comlinkAPI.getBreakpoints();
-        }
+        return this.call((api) => api.getBreakpoints());
     }
 
     // ========== Memory Operations ==========
 
     async readMemoryRange(start: number, length: number): Promise<number[] | void> {
-        if (this.comlinkAPI) {
-            return await this.comlinkAPI.readMemoryRange(start, length);
-        }
+        return this.call((api) => api.readMemoryRange(start, length));
     }
 
     async writeMemory(address: number, value: number): Promise<void> {
-        if (this.comlinkAPI) {
-            await this.comlinkAPI.writeMemory(address, value);
-        }
+        await this.call((api) => api.writeMemory(address, value));
     }
 
     async getDebugInfo(): Promise<FilteredDebugData | void> {
-        if (this.comlinkAPI) {
-            return await this.comlinkAPI.getDebugInfo();
-        }
+        return this.call((api) => api.getDebugInfo());
     }
 
     async getMemoryMap(): Promise<MemoryMapData | void> {
-        if (this.comlinkAPI) {
-            return await this.comlinkAPI.getMemoryMap();
-        }
+        return this.call((api) => api.getMemoryMap());
     }
 
     // ========== Configuration ==========
 
     async setCrtBsSupport(enabled: boolean): Promise<void> {
-        if (this.comlinkAPI) {
-            await this.comlinkAPI.setCrtBsSupport(enabled);
-        }
+        await this.call((api) => api.setCrtBsSupport(enabled));
     }
 
     async setDebuggerActive(active: boolean): Promise<void> {
-        if (this.comlinkAPI) {
-            await this.comlinkAPI.setDebuggerActive(active);
-        }
+        await this.call((api) => api.setDebuggerActive(active));
     }
 
     async setCycleAccurateMode(enabled: boolean): Promise<void> {
-        if (this.comlinkAPI) {
-            await this.comlinkAPI.setCycleAccurateMode(enabled);
-        }
+        await this.call((api) => api.setCycleAccurateMode(enabled));
     }
 
     async setCpuProfiling(enabled: boolean): Promise<void> {
-        if (this.comlinkAPI) {
-            await this.comlinkAPI.setCpuProfiling(enabled);
-        }
+        await this.call((api) => api.setCpuProfiling(enabled));
     }
 
     // ========== Input ==========
 
     async keyDown(key: string): Promise<void> {
-        if (this.comlinkAPI) {
-            await this.comlinkAPI.keyDown(key);
-        }
+        await this.call((api) => api.keyDown(key));
     }
 
     // ========== Engine Management ==========
-    
+
     async switchEngine(engineType: 'JS' | 'WASM'): Promise<void> {
-        if (this.comlinkAPI) {
-            return await this.comlinkAPI.switchEngine(engineType);
-        }
-        throw new Error('Worker not initialized');
+        await this.callOrThrow((api) => api.switchEngine(engineType));
     }
-    
+
     async getEngineStatus(): Promise<EngineStatusData> {
-        if (this.comlinkAPI) {
-            return await this.comlinkAPI.getEngineStatus();
-        }
-        throw new Error('Worker not initialized');
+        return this.callOrThrow((api) => api.getEngineStatus());
     }
-    
+
     async compareEngines(): Promise<EngineComparisonData> {
-        if (this.comlinkAPI) {
-            return await this.comlinkAPI.compareEngines();
-        }
-        throw new Error('Worker not initialized');
+        return this.callOrThrow((api) => api.compareEngines());
     }
-    
+
     // Auto-switch feature has been removed for simplicity
 
     // ========== Event Subscriptions (Comlink only) ==========
@@ -262,7 +234,9 @@ export class WorkerManager {
         // Legacy mode removed
     }
 
-    async onClockData(callback: (data: { cycles: number; frequency: number; totalCycles: number }) => void): Promise<(() => void) | void> {
+    async onClockData(
+        callback: (data: { cycles: number; frequency: number; totalCycles: number }) => void,
+    ): Promise<(() => void) | void> {
         if (this.comlinkAPI) {
             const proxiedCallback = Comlink.proxy(callback);
             return await this.comlinkAPI.onClockData(proxiedCallback);

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '4.48.2';
+export const APP_VERSION = '4.48.3';


### PR DESCRIPTION
## Context

Phase 3 of the architecture cleanup (duplication-reduction lens). **Stacked on #170** → #169.

Two repetitive patterns in the worker layer:
- **`WorkerAPI`** kept five `Set<callback>` fields (`video`/`breakpoint`/`status`/`clock`/`runToCursor`), each with identical add / return-unsubscribe / `forEach(cb => cb(value))` code.
- **`WorkerManager`** repeated `if (this.comlinkAPI) return await this.comlinkAPI.x(...)` ~20 times.

## Change

- **`src/apple1/Subscribable.ts`** — a generic `subscribe`/`emit`/`size` event source with built-in **listener error isolation**. All five WorkerAPI events now use it. Error isolation (previously special-cased only on the video path via `console.error`) now applies uniformly — a throwing UI listener can no longer abort dispatch to its siblings (same pattern `WasmEngine` already uses for breakpoint listeners).
- The video path keeps its **push-current-frame-on-subscribe** behaviour, which guards the late-subscriber power-on-frame regression (PR #166).
- **`WorkerManager.call()` / `callOrThrow()`** helpers — the ~20 simple forwarding methods collapse to one-liners. The throw-on-uninitialized methods (`switchEngine`/`getEngineStatus`/`compareEngines`) use `callOrThrow`. The 5 Comlink-proxy subscription methods are left as-is (distinct proxy logic).

## Verification

- `yarn test:ci` green: **727 passed, 19 skipped** (+5 new `Subscribable` unit tests; the existing video-frame-on-subscribe replay test still passes).
- No change to dispatch semantics — pure de-duplication plus uniform error isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal event handling infrastructure to enhance system stability and reliability. Improved error isolation in event listeners to ensure that errors in one listener don't affect the delivery of events to other listeners, maintaining consistent and robust operation.

* **Chores**
  * Version bumped to 4.48.3.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stid/Apple1JS/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->