### PR TITLE
refactor: extract readCpuRegisters helper to de-duplicate register extraction

### DIFF
--- a/src/components/CompactCpuRegisters.tsx
+++ b/src/components/CompactCpuRegisters.tsx
@@ -2,7 +2,7 @@ import React, { memo } from 'react';
 import { FilteredDebugData } from '../apple1/types/worker-messages';
 import AddressLink from './AddressLink';
 import { Formatters } from '../utils/formatters';
-import { getDebugValueOrDefault } from '../utils/debug-helpers';
+import { readCpuRegisters } from '../utils/debug-helpers';
 import type { WorkerManager } from '../services/WorkerManager';
 
 interface CompactCpuRegistersProps {
@@ -14,27 +14,17 @@ interface CompactCpuRegistersProps {
 const { formatHex } = Formatters;
 
 const CompactCpuRegistersComponent: React.FC<CompactCpuRegistersProps> = ({ debugInfo, workerManager }) => {
-    const cpu = debugInfo.cpu || {};
-    
-    // Extract register values with defaults
+    const { pc, a, x, y, s, flags } = readCpuRegisters(debugInfo.cpu || {});
+
+    // Format register values for display
     const registers = {
-        pc: formatHex(getDebugValueOrDefault(cpu.REG_PC || cpu.PC, 0), 4),
-        a: formatHex(getDebugValueOrDefault(cpu.REG_A || cpu.A, 0), 2),
-        x: formatHex(getDebugValueOrDefault(cpu.REG_X || cpu.X, 0), 2),
-        y: formatHex(getDebugValueOrDefault(cpu.REG_Y || cpu.Y, 0), 2),
-        sp: formatHex(getDebugValueOrDefault(cpu.REG_S || cpu.S, 0), 2),
+        pc: formatHex(pc, 4),
+        a: formatHex(a, 2),
+        x: formatHex(x, 2),
+        y: formatHex(y, 2),
+        sp: formatHex(s, 2),
     };
-    
-    // Extract flag values
-    const flags = {
-        n: cpu.FLAG_N === 'SET' || cpu.N === 'SET',
-        v: cpu.FLAG_V === 'SET' || cpu.V === 'SET',
-        d: cpu.FLAG_D === 'SET' || cpu.D === 'SET',
-        i: cpu.FLAG_I === 'SET' || cpu.I === 'SET',
-        z: cpu.FLAG_Z === 'SET' || cpu.Z === 'SET',
-        c: cpu.FLAG_C === 'SET' || cpu.C === 'SET',
-    };
-    
+
     return (
         <div className="bg-surface-secondary/50 border-t border-border-subtle px-md py-xs">
             <div className="flex items-center justify-between text-xs">
@@ -42,8 +32,8 @@ const CompactCpuRegistersComponent: React.FC<CompactCpuRegistersProps> = ({ debu
                 <div className="flex items-center gap-md">
                     <div className="flex items-center gap-xs">
                         <span className="text-text-secondary font-medium">PC:</span>
-                        <AddressLink 
-                            address={parseInt(registers.pc.replace('$', ''), 16)} 
+                        <AddressLink
+                            address={parseInt(registers.pc.replace('$', ''), 16)}
                             className="font-mono"
                             {...(workerManager !== undefined && { workerManager })}
                             showContextMenu={true}
@@ -67,7 +57,7 @@ const CompactCpuRegistersComponent: React.FC<CompactCpuRegistersProps> = ({ debu
                         <span className="font-mono text-data-value">{registers.sp}</span>
                     </div>
                 </div>
-                
+
                 {/* Flags */}
                 <div className="flex items-center gap-xs">
                     <span className="text-text-secondary font-medium mr-xs">Flags:</span>
@@ -89,51 +79,22 @@ const CompactCpuRegistersComponent: React.FC<CompactCpuRegistersProps> = ({ debu
 
 // Custom comparison function to check if register values actually changed
 const areRegistersEqual = (prevProps: CompactCpuRegistersProps, nextProps: CompactCpuRegistersProps): boolean => {
-    const prevCpu = prevProps.debugInfo.cpu || {};
-    const nextCpu = nextProps.debugInfo.cpu || {};
-    
-    // Compare register values with consistent formatting
-    const prevRegs = {
-        pc: formatHex(getDebugValueOrDefault(prevCpu.REG_PC || prevCpu.PC, 0), 4),
-        a: formatHex(getDebugValueOrDefault(prevCpu.REG_A || prevCpu.A, 0), 2),
-        x: formatHex(getDebugValueOrDefault(prevCpu.REG_X || prevCpu.X, 0), 2),
-        y: formatHex(getDebugValueOrDefault(prevCpu.REG_Y || prevCpu.Y, 0), 2),
-        sp: formatHex(getDebugValueOrDefault(prevCpu.REG_S || prevCpu.S, 0), 2),
-        flagN: prevCpu.FLAG_N === 'SET' || prevCpu.N === 'SET',
-        flagV: prevCpu.FLAG_V === 'SET' || prevCpu.V === 'SET',
-        flagD: prevCpu.FLAG_D === 'SET' || prevCpu.D === 'SET',
-        flagI: prevCpu.FLAG_I === 'SET' || prevCpu.I === 'SET',
-        flagZ: prevCpu.FLAG_Z === 'SET' || prevCpu.Z === 'SET',
-        flagC: prevCpu.FLAG_C === 'SET' || prevCpu.C === 'SET',
-    };
-    
-    const nextRegs = {
-        pc: formatHex(getDebugValueOrDefault(nextCpu.REG_PC || nextCpu.PC, 0), 4),
-        a: formatHex(getDebugValueOrDefault(nextCpu.REG_A || nextCpu.A, 0), 2),
-        x: formatHex(getDebugValueOrDefault(nextCpu.REG_X || nextCpu.X, 0), 2),
-        y: formatHex(getDebugValueOrDefault(nextCpu.REG_Y || nextCpu.Y, 0), 2),
-        sp: formatHex(getDebugValueOrDefault(nextCpu.REG_S || nextCpu.S, 0), 2),
-        flagN: nextCpu.FLAG_N === 'SET' || nextCpu.N === 'SET',
-        flagV: nextCpu.FLAG_V === 'SET' || nextCpu.V === 'SET',
-        flagD: nextCpu.FLAG_D === 'SET' || nextCpu.D === 'SET',
-        flagI: nextCpu.FLAG_I === 'SET' || nextCpu.I === 'SET',
-        flagZ: nextCpu.FLAG_Z === 'SET' || nextCpu.Z === 'SET',
-        flagC: nextCpu.FLAG_C === 'SET' || nextCpu.C === 'SET',
-    };
-    
+    const prev = readCpuRegisters(prevProps.debugInfo.cpu || {});
+    const next = readCpuRegisters(nextProps.debugInfo.cpu || {});
+
     // Return true if all values are equal (prevents re-render)
     return (
-        prevRegs.pc === nextRegs.pc &&
-        prevRegs.a === nextRegs.a &&
-        prevRegs.x === nextRegs.x &&
-        prevRegs.y === nextRegs.y &&
-        prevRegs.sp === nextRegs.sp &&
-        prevRegs.flagN === nextRegs.flagN &&
-        prevRegs.flagV === nextRegs.flagV &&
-        prevRegs.flagD === nextRegs.flagD &&
-        prevRegs.flagI === nextRegs.flagI &&
-        prevRegs.flagZ === nextRegs.flagZ &&
-        prevRegs.flagC === nextRegs.flagC
+        prev.pc === next.pc &&
+        prev.a === next.a &&
+        prev.x === next.x &&
+        prev.y === next.y &&
+        prev.s === next.s &&
+        prev.flags.n === next.flags.n &&
+        prev.flags.v === next.flags.v &&
+        prev.flags.d === next.flags.d &&
+        prev.flags.i === next.flags.i &&
+        prev.flags.z === next.flags.z &&
+        prev.flags.c === next.flags.c
     );
 };
 

--- a/src/utils/__tests__/debug-helpers-cpu-registers.vitest.test.ts
+++ b/src/utils/__tests__/debug-helpers-cpu-registers.vitest.test.ts
@@ -1,0 +1,43 @@
+import { readCpuRegisters } from '../debug-helpers';
+
+describe('readCpuRegisters', () => {
+    it('reads the nested-flattened convention (REG_*/FLAG_*)', () => {
+        const r = readCpuRegisters({
+            REG_PC: 0x1234,
+            REG_A: 0x10,
+            REG_X: 0x20,
+            REG_Y: 0x30,
+            REG_S: 0xff,
+            FLAG_N: 'SET',
+            FLAG_V: 'CLR',
+            FLAG_D: 'CLR',
+            FLAG_I: 'SET',
+            FLAG_Z: 'CLR',
+            FLAG_C: 'SET',
+        });
+        expect(r.pc).toBe(0x1234);
+        expect(r.a).toBe(0x10);
+        expect(r.s).toBe(0xff);
+        expect(r.flags).toEqual({ n: true, v: false, d: false, i: true, z: false, c: true });
+    });
+
+    it('falls back to the flat convention (PC/N) when REG_*/FLAG_* are absent', () => {
+        const r = readCpuRegisters({ PC: 0xabcd, X: 0x42, N: 'SET', C: 'CLR' });
+        expect(r.pc).toBe(0xabcd);
+        expect(r.x).toBe(0x42);
+        expect(r.flags.n).toBe(true);
+        expect(r.flags.c).toBe(false);
+    });
+
+    it('defaults missing registers to 0 and missing flags to false', () => {
+        const r = readCpuRegisters({});
+        expect(r).toEqual({
+            pc: 0,
+            a: 0,
+            x: 0,
+            y: 0,
+            s: 0,
+            flags: { n: false, v: false, d: false, i: false, z: false, c: false },
+        });
+    });
+});

--- a/src/utils/debug-helpers.ts
+++ b/src/utils/debug-helpers.ts
@@ -29,16 +29,16 @@ export function getDebugValue(value: unknown): string | number | undefined {
  */
 export function getDebugValueOrDefault(
     value: string | number | object | undefined,
-    defaultValue: string | number
+    defaultValue: string | number,
 ): string | number {
     if (value === undefined || value === null) {
         return defaultValue;
     }
-    
+
     if (isStringOrNumber(value)) {
         return value;
     }
-    
+
     // If it's an object (like _PERF_DATA), return the default
     return defaultValue;
 }
@@ -47,23 +47,20 @@ export function getDebugValueOrDefault(
  * Extract a numeric value from a debug value that might be a hex string
  * Handles both string values like "$FF" and numeric values
  */
-export function getNumericDebugValue(
-    value: string | number | object | undefined,
-    defaultValue: number
-): number {
+export function getNumericDebugValue(value: string | number | object | undefined, defaultValue: number): number {
     const extracted = getDebugValueOrDefault(value, defaultValue);
-    
+
     if (typeof extracted === 'number') {
         return extracted;
     }
-    
+
     // Handle hex strings like "$FF" or "0xFF"
     if (typeof extracted === 'string') {
         const cleanValue = extracted.replace('$', '');
         const parsed = parseInt(cleanValue, 16);
         return isNaN(parsed) ? defaultValue : parsed;
     }
-    
+
     return defaultValue;
 }
 
@@ -83,4 +80,45 @@ export function getDebugBoolean(value: unknown): boolean {
  */
 export function isDebugObject(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Structural shape of a CPU debug record (avoids coupling utils to apple1 types). */
+type CpuDebugFields = { [key: string]: string | number | object | undefined };
+
+/** Normalized CPU register snapshot: raw register values + boolean flags. */
+export interface CpuRegisters {
+    pc: string | number;
+    a: string | number;
+    x: string | number;
+    y: string | number;
+    s: string | number;
+    flags: { n: boolean; v: boolean; d: boolean; i: boolean; z: boolean; c: boolean };
+}
+
+/**
+ * Extract CPU registers and flags from debug data, normalizing the two source
+ * conventions the engines emit: nested-flattened (`REG_PC`, `FLAG_N`) and flat
+ * (`PC`, `N`). Centralizes the `cpu.REG_X || cpu.X` / `cpu.FLAG_X === 'SET'`
+ * fallbacks that were copied across the register views.
+ */
+export function readCpuRegisters(cpu: CpuDebugFields): CpuRegisters {
+    const reg = (regKey: string, altKey: string): string | number =>
+        getDebugValueOrDefault(cpu[regKey] || cpu[altKey], 0);
+    const flag = (flagKey: string, altKey: string): boolean => cpu[flagKey] === 'SET' || cpu[altKey] === 'SET';
+
+    return {
+        pc: reg('REG_PC', 'PC'),
+        a: reg('REG_A', 'A'),
+        x: reg('REG_X', 'X'),
+        y: reg('REG_Y', 'Y'),
+        s: reg('REG_S', 'S'),
+        flags: {
+            n: flag('FLAG_N', 'N'),
+            v: flag('FLAG_V', 'V'),
+            d: flag('FLAG_D', 'D'),
+            i: flag('FLAG_I', 'I'),
+            z: flag('FLAG_Z', 'Z'),
+            c: flag('FLAG_C', 'C'),
+        },
+    };
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '4.48.3';
+export const APP_VERSION = '4.48.4';


### PR DESCRIPTION
## Context

Phase 4 of the architecture cleanup (duplication-reduction lens). **Stacked on #171** → #170 → #169.

`CompactCpuRegisters` extracted CPU registers/flags with the same `cpu.REG_X || cpu.X` and `cpu.FLAG_X === 'SET' || cpu.X === 'SET'` source-fallback **three times** — once in the render body and once per side of its `memo` comparator.

## Change

- **`readCpuRegisters(cpu)`** in `debug-helpers.ts` — returns a normalized snapshot (raw register values + boolean flags) that centralizes the nested-flattened (`REG_PC`/`FLAG_N`) vs flat (`PC`/`N`) fallback. `CompactCpuRegisters` reads it once for render and once per side in the comparator.

## Scope notes (what I deliberately did *not* touch)

This phase came in smaller than the original sketch on purpose — the duplication-reduction lens plus the no-downgrade rule ruled the rest out:

- **InspectorView** keeps raw display strings (`'SET'`/`'CLR'`), distinct flag defaults (`FLAG_I` defaults `SET`), and many hw/perf fields. Folding it into the boolean snapshot would **change its displayed output** — a downgrade — so it stays as-is.
- **AddressLink** already formats via `Formatters` (no raw `toString(16)` duplication to remove).
- **Breakpoint "dual source"** is not duplication: `EmulationContext` is the control surface (toggle/clear/hit-events, `Set`), `WorkerDataContext` is the polling surface (array via dataSync). Unifying them is an architectural change with real re-render/sync regression risk — **deferred**.
- **workerManager prop-drill → context** is a prop-drilling fix, not duplication — **deferred**.

## Verification

- `yarn test:ci` green: **730 passed, 19 skipped** (+3 `readCpuRegisters` unit tests; all 159 component tests pass — register display unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated app version to 4.48.4.

* **Tests**
  * Enhanced test coverage for CPU register handling.

* **Refactor**
  * Improved internal CPU register and flag computation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stid/Apple1JS/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->