### PR TITLE
chore: gitignore private Cloudflare deployment notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ wasm-cpu/target/
 # private global /stid-sdd-* tooling; not portable, so never committed to this public repo)
 .claude/rules/sdd-conventions.md
 docs/specs/
+# Private hosting/deployment notes — we publish via Cloudflare but don't disclose the
+# migration playbook/account IDs in the public repo (kept in the maintainer's private vault).
+docs/active/cloudflare-migration-plan.md

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '4.48.5';
+export const APP_VERSION = '4.48.6';


### PR DESCRIPTION
## What

Adds `docs/active/cloudflare-migration-plan.md` to `.gitignore` so the detailed
deployment playbook never lands in the public repo, and bumps `src/version.ts`
to 4.48.6 (chore → patch).

## Why

We publish via Cloudflare and that's fine to be known, but we don't want to
disclose the migration internals — build command, account IDs, step-by-step
gotchas, decommission steps. Those notes are preserved privately outside the repo.

The file was untracked (never committed), so this only prevents future accidental
commits; no git history needed scrubbing.

## Notes

- Follows the existing `.gitignore` pattern for local/private artifacts (the SDD
  adapter, `.claude/hooks/`, etc.).
- No code changes; only `.gitignore` + version bump.
- Gate green locally: `lint` + `type-check` + `test:ci` (730 passed, 19 browser-only skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Patch version updated to 4.48.6

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stid/Apple1JS/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->