### PR TITLE
feat: engine-switch loading indicator + persist debugger view state

### DIFF
--- a/src/components/AppContent.tsx
+++ b/src/components/AppContent.tsx
@@ -22,6 +22,12 @@ type Props = {
     apple1Instance?: IInspectableComponent | null;
 };
 
+type RightTab = 'info' | 'inspector' | 'debugger';
+
+// Guards for persisted UI prefs: reject valid-JSON-but-invalid values from localStorage.
+const isNumber = (v: unknown): v is number => typeof v === 'number';
+const isRightTab = (v: unknown): v is RightTab => v === 'info' || v === 'inspector' || v === 'debugger';
+
 interface AppContentInnerProps extends Props {
     rightTab: 'info' | 'inspector' | 'debugger';
     setRightTab: React.Dispatch<React.SetStateAction<'info' | 'inspector' | 'debugger'>>;
@@ -49,8 +55,12 @@ const AppContentInner = ({
     const { safeSetTimeout } = useUnmountSafe();
 
     // Persist debugger view addresses across tab switches AND reloads.
-    const [memoryViewAddress, setMemoryViewAddress] = useLocalStorageState('apple1js_ui_memAddr', 0x0000);
-    const [disassemblerAddress, setDisassemblerAddress] = useLocalStorageState('apple1js_ui_disasmAddr', 0x0000);
+    const [memoryViewAddress, setMemoryViewAddress] = useLocalStorageState('apple1js_ui_memAddr', 0x0000, isNumber);
+    const [disassemblerAddress, setDisassemblerAddress] = useLocalStorageState(
+        'apple1js_ui_disasmAddr',
+        0x0000,
+        isNumber,
+    );
 
     // Subscribe to navigation events and switch to debugger tab
     useEffect(() => {
@@ -383,10 +393,7 @@ const AppContentInner = ({
 };
 
 export const AppContent = ({ workerManager, apple1Instance }: Props): JSX.Element => {
-    const [rightTab, setRightTab] = useLocalStorageState<'info' | 'inspector' | 'debugger'>(
-        'apple1js_ui_rightTab',
-        'info',
-    );
+    const [rightTab, setRightTab] = useLocalStorageState<RightTab>('apple1js_ui_rightTab', 'info', isRightTab);
     const [pendingNavigation, setPendingNavigation] = useState<{
         address: number;
         target: 'memory' | 'disassembly';

--- a/src/components/AppContent.tsx
+++ b/src/components/AppContent.tsx
@@ -15,6 +15,7 @@ import type { WorkerManager } from '../services/WorkerManager';
 import type { EngineStatusData } from '../apple1/types/worker-messages';
 import { loggingService } from '../services/LoggingService';
 import { useUnmountSafe } from '../hooks/useUnmountSafe';
+import { useLocalStorageState } from '../hooks/useLocalStorageState';
 
 type Props = {
     workerManager: WorkerManager;
@@ -47,9 +48,9 @@ const AppContentInner = ({
     const { showToast } = useToast();
     const { safeSetTimeout } = useUnmountSafe();
 
-    // Persist debugger view states across tab switches
-    const [memoryViewAddress, setMemoryViewAddress] = useState(0x0000);
-    const [disassemblerAddress, setDisassemblerAddress] = useState(0x0000);
+    // Persist debugger view addresses across tab switches AND reloads.
+    const [memoryViewAddress, setMemoryViewAddress] = useLocalStorageState('apple1js_ui_memAddr', 0x0000);
+    const [disassemblerAddress, setDisassemblerAddress] = useLocalStorageState('apple1js_ui_disasmAddr', 0x0000);
 
     // Subscribe to navigation events and switch to debugger tab
     useEffect(() => {
@@ -382,25 +383,34 @@ const AppContentInner = ({
 };
 
 export const AppContent = ({ workerManager, apple1Instance }: Props): JSX.Element => {
-    const [rightTab, setRightTab] = useState<'info' | 'inspector' | 'debugger'>('info');
+    const [rightTab, setRightTab] = useLocalStorageState<'info' | 'inspector' | 'debugger'>(
+        'apple1js_ui_rightTab',
+        'info',
+    );
     const [pendingNavigation, setPendingNavigation] = useState<{
         address: number;
         target: 'memory' | 'disassembly';
     } | null>(null);
 
-    const handleBreakpointHit = useCallback((address: number) => {
-        // When any breakpoint hits, switch to debugger tab and disassembly view
-        setPendingNavigation({ address, target: 'disassembly' });
-        setRightTab('debugger');
-    }, []);
-
-    const handleRunToCursorSet = useCallback((address: number | null) => {
-        // When run-to-cursor is set, switch to debugger tab and disassembly view
-        if (address !== null) {
+    const handleBreakpointHit = useCallback(
+        (address: number) => {
+            // When any breakpoint hits, switch to debugger tab and disassembly view
             setPendingNavigation({ address, target: 'disassembly' });
             setRightTab('debugger');
-        }
-    }, []);
+        },
+        [setRightTab],
+    );
+
+    const handleRunToCursorSet = useCallback(
+        (address: number | null) => {
+            // When run-to-cursor is set, switch to debugger tab and disassembly view
+            if (address !== null) {
+                setPendingNavigation({ address, target: 'disassembly' });
+                setRightTab('debugger');
+            }
+        },
+        [setRightTab],
+    );
 
     return (
         <WorkerDataProvider workerManager={workerManager}>

--- a/src/components/DebuggerLayout.tsx
+++ b/src/components/DebuggerLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import DisassemblerPaginated from './DisassemblerPaginated';
 import MemoryViewerPaginated from './MemoryViewerPaginated';
 import StackViewer from './StackViewer';
@@ -8,6 +8,7 @@ import { IInspectableComponent } from '../core/types';
 import { useDebuggerNavigation } from '../contexts/DebuggerNavigationContext';
 import { useWorkerData } from '../contexts/WorkerDataContext';
 import { getDebugValueOrDefault, getNumericDebugValue } from '../utils/debug-helpers';
+import { useLocalStorageState } from '../hooks/useLocalStorageState';
 import AddressLink from './AddressLink';
 import type { WorkerManager } from '../services/WorkerManager';
 
@@ -33,7 +34,7 @@ const DebuggerLayout: React.FC<DebuggerLayoutProps> = ({
     disassemblerAddress,
     setDisassemblerAddress,
 }) => {
-    const [activeView, setActiveView] = useState<DebugView>('overview');
+    const [activeView, setActiveView] = useLocalStorageState<DebugView>('apple1js_ui_debugView', 'overview');
     const { subscribeToNavigation } = useDebuggerNavigation();
     const { debugInfo, setDebuggerActive } = useWorkerData();
 
@@ -49,7 +50,7 @@ const DebuggerLayout: React.FC<DebuggerLayoutProps> = ({
             }
             onNavigationHandled?.();
         }
-    }, [initialNavigation, onNavigationHandled, setDisassemblerAddress, setMemoryViewAddress]);
+    }, [initialNavigation, onNavigationHandled, setActiveView, setDisassemblerAddress, setMemoryViewAddress]);
 
     // Control debugger visibility state using WorkerDataContext
     useEffect(() => {
@@ -77,7 +78,7 @@ const DebuggerLayout: React.FC<DebuggerLayoutProps> = ({
         });
 
         return unsubscribe;
-    }, [subscribeToNavigation, setDisassemblerAddress, setMemoryViewAddress]);
+    }, [subscribeToNavigation, setActiveView, setDisassemblerAddress, setMemoryViewAddress]);
 
     return (
         <div className="flex flex-col h-full">

--- a/src/components/DebuggerLayout.tsx
+++ b/src/components/DebuggerLayout.tsx
@@ -25,6 +25,9 @@ interface DebuggerLayoutProps {
 
 type DebugView = 'overview' | 'memory' | 'disassembly';
 
+// Guard for the persisted view pref: reject valid-JSON-but-invalid values from localStorage.
+const isDebugView = (v: unknown): v is DebugView => v === 'overview' || v === 'memory' || v === 'disassembly';
+
 const DebuggerLayout: React.FC<DebuggerLayoutProps> = ({
     workerManager,
     initialNavigation,
@@ -34,7 +37,11 @@ const DebuggerLayout: React.FC<DebuggerLayoutProps> = ({
     disassemblerAddress,
     setDisassemblerAddress,
 }) => {
-    const [activeView, setActiveView] = useLocalStorageState<DebugView>('apple1js_ui_debugView', 'overview');
+    const [activeView, setActiveView] = useLocalStorageState<DebugView>(
+        'apple1js_ui_debugView',
+        'overview',
+        isDebugView,
+    );
     const { subscribeToNavigation } = useDebuggerNavigation();
     const { debugInfo, setDebuggerActive } = useWorkerData();
 

--- a/src/components/EngineSwitcher.tsx
+++ b/src/components/EngineSwitcher.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import type { WorkerManager } from '../services/WorkerManager';
 import type { EngineStatusData } from '../apple1/types/worker-messages';
 import { loggingService } from '../services/LoggingService';
+import Spinner from './Spinner';
 
 interface EngineSwitcherProps {
     workerManager: WorkerManager;
@@ -105,6 +106,13 @@ const EngineSwitcher: React.FC<EngineSwitcherProps> = ({ workerManager }) => {
                 >
                     WASM Engine
                 </button>
+
+                {isSwitching && (
+                    <span className="flex items-center gap-xs text-xs text-text-secondary">
+                        <Spinner label="Switching engine" />
+                        Switching…
+                    </span>
+                )}
             </div>
 
             {/* Engine Statistics */}

--- a/src/components/ExecutionControlsCluster.tsx
+++ b/src/components/ExecutionControlsCluster.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect } from 'react';
 import { useEmulation } from '../contexts/EmulationContext';
 import type { WorkerManager } from '../services/WorkerManager';
 import RunStateBadge from './RunStateBadge';
+import Spinner from './Spinner';
 
 interface ExecutionControlsClusterProps {
     workerManager: WorkerManager;
@@ -101,6 +102,12 @@ const ExecutionControlsCluster: React.FC<ExecutionControlsClusterProps> = ({
             {/* Engine switch — labelled "Engine", kept distinct from run-state (AC-7/AC-8). */}
             <div className="flex items-center gap-xs ml-sm" role="group" aria-label="CPU engine">
                 <span className="text-xs text-text-secondary">Engine:</span>
+                {isSwitchingEngine && (
+                    <span className="flex items-center gap-xs text-xs text-text-secondary">
+                        <Spinner label="Switching engine" />
+                        Switching…
+                    </span>
+                )}
                 {ENGINES.map((engine) => {
                     const active = engine === currentEngine;
                     const unavailable = engine === 'WASM' && !wasmAvailable;

--- a/src/components/Spinner.tsx
+++ b/src/components/Spinner.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+interface SpinnerProps {
+    /** Accessible label announced while busy. */
+    label?: string;
+    className?: string;
+}
+
+/**
+ * Small, token-styled busy indicator. Announced to assistive tech as a polite status
+ * region; the spinning ring itself is decorative (aria-hidden).
+ */
+const Spinner: React.FC<SpinnerProps> = ({ label = 'Loading', className = '' }) => (
+    <span role="status" aria-label={label} data-testid="spinner" className={`inline-flex items-center ${className}`}>
+        <span
+            aria-hidden="true"
+            className="inline-block w-3 h-3 rounded-full border-2 border-current border-t-transparent animate-spin"
+        />
+    </span>
+);
+
+export default Spinner;

--- a/src/components/__tests__/EngineSwitcher-loading-indicator.vitest.test.tsx
+++ b/src/components/__tests__/EngineSwitcher-loading-indicator.vitest.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { createMockWorkerManager } from '../../test-support/mocks/WorkerManager.mock';
+import type { WorkerManager } from '../../services/WorkerManager';
+import EngineSwitcher from '../EngineSwitcher';
+
+describe('EngineSwitcher loading indicator', () => {
+    let wm: WorkerManager;
+    beforeEach(() => {
+        wm = createMockWorkerManager();
+        vi.clearAllMocks();
+        vi.mocked(wm.getEngineStatus).mockResolvedValue({
+            currentEngine: 'JS',
+            availableEngines: ['JS', 'WASM'],
+            switchCount: 0,
+            lastSwitchTime: 0,
+        });
+    });
+
+    it('shows a spinner while a switch is in flight', async () => {
+        // Keep the switch pending so the switching state stays observable.
+        vi.mocked(wm.switchEngine).mockReturnValue(new Promise(() => {}));
+        render(<EngineSwitcher workerManager={wm} />);
+
+        const wasmBtn = await screen.findByRole('button', { name: /WASM Engine/i });
+        expect(screen.queryByTestId('spinner')).toBeNull();
+        fireEvent.click(wasmBtn);
+        await waitFor(() => expect(screen.getByTestId('spinner')).toBeInTheDocument());
+    });
+});

--- a/src/components/__tests__/ExecutionControlsCluster-loading-indicator.vitest.test.tsx
+++ b/src/components/__tests__/ExecutionControlsCluster-loading-indicator.vitest.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { createMockWorkerManager } from '../../test-support/mocks/WorkerManager.mock';
+import type { WorkerManager } from '../../services/WorkerManager';
+import ExecutionControlsCluster from '../ExecutionControlsCluster';
+
+const emu = vi.hoisted(() => ({
+    isPaused: false,
+    executionState: 'running' as const,
+    currentPC: 0,
+    pause: vi.fn(),
+    resume: vi.fn(),
+    step: vi.fn(),
+}));
+vi.mock('../../contexts/EmulationContext', () => ({
+    useEmulation: () => emu,
+    EmulationProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+describe('ExecutionControlsCluster loading indicator', () => {
+    let wm: WorkerManager;
+    beforeEach(() => {
+        wm = createMockWorkerManager();
+        vi.clearAllMocks();
+    });
+
+    const renderCluster = (isSwitchingEngine: boolean) =>
+        render(
+            <ExecutionControlsCluster
+                workerManager={wm}
+                currentEngine="WASM"
+                wasmAvailable={true}
+                isSwitchingEngine={isSwitchingEngine}
+                onEngineSwitch={vi.fn()}
+            />,
+        );
+
+    it('shows a spinner and "Switching" while the engine is switching', () => {
+        renderCluster(true);
+        expect(screen.getByTestId('spinner')).toBeInTheDocument();
+        expect(screen.getByText(/switching/i)).toBeInTheDocument();
+    });
+
+    it('shows no spinner when not switching', () => {
+        renderCluster(false);
+        expect(screen.queryByTestId('spinner')).toBeNull();
+    });
+});

--- a/src/components/__tests__/Spinner.vitest.test.tsx
+++ b/src/components/__tests__/Spinner.vitest.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import Spinner from '../Spinner';
+
+describe('Spinner', () => {
+    it('renders an accessible, animated busy indicator', () => {
+        render(<Spinner label="Switching…" />);
+        const spinner = screen.getByTestId('spinner');
+        // announced to assistive tech as busy
+        expect(spinner).toHaveAttribute('role', 'status');
+        expect(spinner).toHaveAttribute('aria-label', 'Switching…');
+        // visually animated (Tailwind's spin utility)
+        expect(spinner.querySelector('.animate-spin')).not.toBeNull();
+    });
+
+    it('defaults its accessible label when none is given', () => {
+        render(<Spinner />);
+        expect(screen.getByTestId('spinner')).toHaveAttribute('aria-label', 'Loading');
+    });
+});

--- a/src/hooks/__tests__/useLocalStorageState.vitest.test.ts
+++ b/src/hooks/__tests__/useLocalStorageState.vitest.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useLocalStorageState } from '../useLocalStorageState';
+
+const KEY = 'apple1js_ui_test';
+
+// A deterministic in-memory Storage so the test never depends on the (flaky under
+// full-suite worker sharing) jsdom localStorage instance.
+function makeMemoryStorage(): Storage {
+    const map = new Map<string, string>();
+    return {
+        get length() {
+            return map.size;
+        },
+        clear: () => map.clear(),
+        getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+        key: (i: number) => [...map.keys()][i] ?? null,
+        removeItem: (k: string) => void map.delete(k),
+        setItem: (k: string, v: string) => void map.set(k, String(v)),
+    };
+}
+
+let originalDescriptor: PropertyDescriptor | undefined;
+
+describe('useLocalStorageState', () => {
+    beforeEach(() => {
+        originalDescriptor = Object.getOwnPropertyDescriptor(window, 'localStorage');
+        Object.defineProperty(window, 'localStorage', {
+            value: makeMemoryStorage(),
+            configurable: true,
+            writable: true,
+        });
+    });
+    afterEach(() => {
+        vi.restoreAllMocks();
+        if (originalDescriptor) {
+            Object.defineProperty(window, 'localStorage', originalDescriptor);
+        }
+    });
+
+    it('returns the default when nothing is stored', () => {
+        const { result } = renderHook(() => useLocalStorageState(KEY, 'overview'));
+        expect(result.current[0]).toBe('overview');
+    });
+
+    it('hydrates from an existing stored value', () => {
+        window.localStorage.setItem(KEY, JSON.stringify('memory'));
+        const { result } = renderHook(() => useLocalStorageState(KEY, 'overview'));
+        expect(result.current[0]).toBe('memory');
+    });
+
+    it('writes through to localStorage on change (value and updater forms)', () => {
+        const { result } = renderHook(() => useLocalStorageState(KEY, 0x0000));
+        act(() => result.current[1](0x1234));
+        expect(result.current[0]).toBe(0x1234);
+        expect(JSON.parse(window.localStorage.getItem(KEY)!)).toBe(0x1234);
+
+        act(() => result.current[1]((prev) => prev + 1));
+        expect(result.current[0]).toBe(0x1235);
+    });
+
+    it('falls back to the default on corrupt JSON without throwing', () => {
+        window.localStorage.setItem(KEY, '{not valid json');
+        const { result } = renderHook(() => useLocalStorageState(KEY, 'overview'));
+        expect(result.current[0]).toBe('overview');
+    });
+
+    it('is safe when localStorage access throws', () => {
+        vi.spyOn(window.localStorage, 'getItem').mockImplementation(() => {
+            throw new Error('blocked');
+        });
+        const { result } = renderHook(() => useLocalStorageState(KEY, 'info'));
+        expect(result.current[0]).toBe('info');
+    });
+});

--- a/src/hooks/__tests__/useLocalStorageState.vitest.test.ts
+++ b/src/hooks/__tests__/useLocalStorageState.vitest.test.ts
@@ -72,4 +72,19 @@ describe('useLocalStorageState', () => {
         const { result } = renderHook(() => useLocalStorageState(KEY, 'info'));
         expect(result.current[0]).toBe('info');
     });
+
+    it('falls back to the default when a valid-JSON value fails the validator', () => {
+        // valid JSON, but not an allowed value (e.g. a renamed/hand-edited enum)
+        window.localStorage.setItem(KEY, JSON.stringify('settings'));
+        const isTab = (v: unknown): v is 'info' | 'debugger' => v === 'info' || v === 'debugger';
+        const { result } = renderHook(() => useLocalStorageState(KEY, 'info', isTab));
+        expect(result.current[0]).toBe('info');
+    });
+
+    it('hydrates a stored value that passes the validator', () => {
+        window.localStorage.setItem(KEY, JSON.stringify('debugger'));
+        const isTab = (v: unknown): v is 'info' | 'debugger' => v === 'info' || v === 'debugger';
+        const { result } = renderHook(() => useLocalStorageState(KEY, 'info', isTab));
+        expect(result.current[0]).toBe('debugger');
+    });
 });

--- a/src/hooks/useLocalStorageState.ts
+++ b/src/hooks/useLocalStorageState.ts
@@ -1,0 +1,35 @@
+import { useCallback, useState } from 'react';
+
+/**
+ * A `useState`-shaped hook that mirrors its value into `localStorage`, so a preference
+ * survives reloads. Reads/writes follow the project's defensive localStorage idiom (see
+ * StatePersistenceService): corrupt or unavailable storage never throws — it falls back to
+ * `defaultValue`. The value is JSON-serialised under `key`.
+ */
+export function useLocalStorageState<T>(key: string, defaultValue: T): [T, (value: T | ((prev: T) => T)) => void] {
+    const [value, setValue] = useState<T>(() => {
+        try {
+            const stored = window.localStorage.getItem(key);
+            return stored !== null ? (JSON.parse(stored) as T) : defaultValue;
+        } catch {
+            return defaultValue;
+        }
+    });
+
+    const set = useCallback(
+        (next: T | ((prev: T) => T)) => {
+            setValue((prev) => {
+                const resolved = typeof next === 'function' ? (next as (p: T) => T)(prev) : next;
+                try {
+                    window.localStorage.setItem(key, JSON.stringify(resolved));
+                } catch {
+                    // Storage unavailable (private mode, quota) — keep in-memory state only.
+                }
+                return resolved;
+            });
+        },
+        [key],
+    );
+
+    return [value, set];
+}

--- a/src/hooks/useLocalStorageState.ts
+++ b/src/hooks/useLocalStorageState.ts
@@ -5,12 +5,24 @@ import { useCallback, useState } from 'react';
  * survives reloads. Reads/writes follow the project's defensive localStorage idiom (see
  * StatePersistenceService): corrupt or unavailable storage never throws — it falls back to
  * `defaultValue`. The value is JSON-serialised under `key`.
+ *
+ * Pass `isValid` (a type guard) to reject stored values that are valid JSON but not valid
+ * app state — e.g. a renamed enum or a hand-edited entry — so a stale/bad value degrades to
+ * `defaultValue` instead of putting the UI into an impossible state.
  */
-export function useLocalStorageState<T>(key: string, defaultValue: T): [T, (value: T | ((prev: T) => T)) => void] {
+export function useLocalStorageState<T>(
+    key: string,
+    defaultValue: T,
+    isValid?: (value: unknown) => value is T,
+): [T, (value: T | ((prev: T) => T)) => void] {
     const [value, setValue] = useState<T>(() => {
         try {
             const stored = window.localStorage.getItem(key);
-            return stored !== null ? (JSON.parse(stored) as T) : defaultValue;
+            if (stored === null) {
+                return defaultValue;
+            }
+            const parsed: unknown = JSON.parse(stored);
+            return isValid && !isValid(parsed) ? defaultValue : (parsed as T);
         } catch {
             return defaultValue;
         }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '4.49.0';
+export const APP_VERSION = '4.50.0';


### PR DESCRIPTION
## What & why

The two deferred follow-ups from the UX-trends pass (the toast feedback system shipped separately in #175). Both apply the same article principle — *the interface gets out of the way* — via real-time feedback and smart defaults. Plain TDD.

## 1. Loading indicator during engine switch

The JS↔WASM switch previously gave no visual feedback (buttons just disabled). Adds a small token-styled, accessible `Spinner` and a "Switching…" label on **both** engine-switch surfaces:
- `ExecutionControlsCluster` (always-visible bar) — driven by `isSwitchingEngine`
- `EngineSwitcher` (debugger overview) — driven by its internal `isSwitching`

## 2. Persist debugger view state across reloads

The debugger forgot where you were on reload. Adds `useLocalStorageState` — a `useState`-shaped hook mirroring `StatePersistenceService`'s defensive localStorage idiom (corrupt/unavailable storage falls back to the default, never throws). Persists:
- the right-hand tab (`Info`/`Inspector`/`Debugger`)
- the debugger sub-view (`Overview`/`Memory`/`Disassembly`)
- the memory and disassembly addresses

Navigation events (breakpoint hit, run-to-cursor, address links) still override the persisted view.

## Testing

- New tests: `Spinner` (2), loading indicator on both surfaces (3), `useLocalStorageState` (5). Full suite green (740 passed).
- The hook test installs an in-memory `Storage` so it's deterministic regardless of full-suite worker ordering (jsdom's shared `localStorage` is flaky under `maxWorkers`).

Pure UI — no CPU/engine-core changes, so the JS/WASM dual-engine parity requirement does not apply.

## Versioning

Branched off `master`; bumped `src/version.ts` 4.48.6 → **4.50.0** (4.49.0 is reserved by the toast PR #175, so the two PRs don't collide on `version.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Debugger view, active tab, and memory/disassembly addresses now persist across sessions via localStorage
  * Visual loading indicator during engine switching; reusable spinner component added

* **Tests**
  * Tests added for spinner, engine-switch loading states, and localStorage-backed state behavior (including validators and error cases)

* **Chores**
  * App version bumped to 4.50.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stid/Apple1JS/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->