### PR TITLE
fix: route save/load state through the active engine (WASM)

### DIFF
--- a/src/apple1/__tests__/Apple1-save-load-engine-routing.vitest.test.ts
+++ b/src/apple1/__tests__/Apple1-save-load-engine-routing.vitest.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Save/Load must route CPU state through the *active* engine and keep both RAM
+ * banks mirrored into the engine's own memory.
+ *
+ * Regression: when the WASM engine is active, the JS `CPU6502` held as
+ * `Apple1.cpu` is dormant, and the WASM engine owns a separate RAM copy. The
+ * old save/load path read/wrote only `this.cpu` and the JS Bus, so saving under
+ * WASM captured stale registers + stale RAM, and loading under WASM never
+ * reached the running engine. These tests inject a spy `ICPUEngine` (no real
+ * WASM needed — that path can only run in a browser) and assert the routing.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Apple1 from '../index';
+import type { ICPUEngine } from '../../core/cpu-interface/ICPUEngine';
+import type { CPU6502State } from '../../core/cpu6502/types';
+import type { IoComponent } from '../../core/types/io';
+import type { VideoState } from '../TSTypes';
+import { RAM_BANK1_START, RAM_BANK1_SIZE, RAM_BANK2_START, RAM_BANK2_SIZE } from '../../core/constants/memory';
+
+const BANK1_MARKER = 0xaa;
+const BANK2_MARKER = 0xbb;
+
+function makeCpuState(pc: number): CPU6502State {
+    return {
+        version: '3.0',
+        PC: pc,
+        A: 0x12,
+        X: 0x34,
+        Y: 0x56,
+        S: 0xfd,
+        N: 1,
+        V: 0,
+        D: 0,
+        I: 1,
+        Z: 0,
+        C: 1,
+        irq: 0,
+        nmi: 0,
+        cycles: 4242,
+        opcode: 0,
+        address: 0,
+        data: 0,
+        pendingIrq: 0,
+        pendingNmi: 0,
+    };
+}
+
+/**
+ * Spy engine: readRange returns a per-bank marker byte so we can tell which
+ * bank a sync touched; saveState returns a sentinel CPU state; loadState /
+ * writeRange record their calls.
+ */
+function makeSpyEngine(savedCpu: CPU6502State) {
+    const readRange = vi.fn((start: number, length: number) => {
+        const marker = start === RAM_BANK1_START ? BANK1_MARKER : BANK2_MARKER;
+        return new Uint8Array(length).fill(marker);
+    });
+    const engine = {
+        engineType: 'WASM' as const,
+        engineVersion: 'spy',
+        isReady: true,
+        ensureReady: vi.fn(async () => undefined),
+        performSingleStep: vi.fn(() => 0),
+        performBulkSteps: vi.fn(),
+        reset: vi.fn(),
+        halt: vi.fn(),
+        saveState: vi.fn(() => savedCpu),
+        loadState: vi.fn(),
+        getRegisters: vi.fn(),
+        setRegisters: vi.fn(),
+        read: vi.fn(() => 0),
+        write: vi.fn(),
+        readRange,
+        writeRange: vi.fn(),
+        loadProgram: vi.fn(),
+        setBreakpoint: vi.fn(),
+        clearBreakpoint: vi.fn(),
+        clearAllBreakpoints: vi.fn(),
+        getBreakpoints: vi.fn(() => []),
+        hasBreakpoint: vi.fn(() => false),
+        getMetrics: vi.fn(),
+        resetMetrics: vi.fn(),
+        getMemoryUsage: vi.fn(() => 0),
+    };
+    return engine as unknown as ICPUEngine & typeof engine;
+}
+
+function makeApple1(): Apple1 {
+    // Minimal IO stubs — Apple1 only wires keyboard and routes display writes.
+    const keyboard = {
+        write: vi.fn(async () => undefined),
+        wire: vi.fn(),
+        reset: vi.fn(),
+    } as unknown as IoComponent;
+    const video = {
+        write: vi.fn(async () => undefined),
+        wire: vi.fn(),
+        reset: vi.fn(),
+    } as unknown as IoComponent<VideoState>;
+    // useDualEngine: false keeps cpuEngine undefined so we control it explicitly.
+    return new Apple1({ video, keyboard, useDualEngine: false });
+}
+
+describe('Apple1 save/load routes through the active engine', () => {
+    let apple1: Apple1;
+
+    beforeEach(() => {
+        apple1 = makeApple1();
+    });
+
+    describe('deprecated saveEmulatorState/loadEmulatorState (live worker path)', () => {
+        it('saveEmulatorState reads CPU + RAM from cpuEngine when present', () => {
+            const savedCpu = makeCpuState(0xc0de);
+            const spy = makeSpyEngine(savedCpu);
+            apple1.cpuEngine = spy;
+
+            const state = apple1.saveEmulatorState();
+
+            // CPU came from the active engine, not the dormant JS cpu
+            expect(spy.saveState).toHaveBeenCalledTimes(1);
+            expect(state.cpu).toBe(savedCpu);
+
+            // RAM was pulled from the active engine for BOTH banks
+            expect(spy.readRange).toHaveBeenCalledWith(RAM_BANK1_START, RAM_BANK1_SIZE);
+            expect(spy.readRange).toHaveBeenCalledWith(RAM_BANK2_START, RAM_BANK2_SIZE);
+            const bank1 = state.ram.find((b) => b.id === 'ram1')!;
+            const bank2 = state.ram.find((b) => b.id === 'ram2')!;
+            expect(bank1.state.data[0]).toBe(BANK1_MARKER);
+            expect(bank2.state.data[0]).toBe(BANK2_MARKER);
+        });
+
+        it('loadEmulatorState writes CPU + both RAM banks into cpuEngine', () => {
+            // Build a valid-shaped state, then overwrite RAM bytes with markers.
+            const baseState = apple1.saveEmulatorState();
+            const loadedCpu = makeCpuState(0x0e00);
+            baseState.cpu = loadedCpu;
+            baseState.ram.find((b) => b.id === 'ram1')!.state.data.fill(0x11);
+            baseState.ram.find((b) => b.id === 'ram2')!.state.data.fill(0x22);
+
+            const spy = makeSpyEngine(makeCpuState(0));
+            apple1.cpuEngine = spy;
+
+            apple1.loadEmulatorState(baseState);
+
+            // CPU loaded into the active engine
+            expect(spy.loadState).toHaveBeenCalledWith(loadedCpu);
+
+            // Restored RAM mirrored into the engine for BOTH banks
+            const writes = spy.writeRange.mock.calls;
+            const bank1Write = writes.find((c) => c[0] === RAM_BANK1_START);
+            const bank2Write = writes.find((c) => c[0] === RAM_BANK2_START);
+            expect(bank1Write?.[1][0]).toBe(0x11);
+            expect(bank2Write?.[1][0]).toBe(0x22);
+        });
+    });
+
+    describe('versioned saveState/applyState', () => {
+        it('saveState reads CPU + RAM from cpuEngine when present', () => {
+            const savedCpu = makeCpuState(0xbeef);
+            const spy = makeSpyEngine(savedCpu);
+            apple1.cpuEngine = spy;
+
+            const state = apple1.saveState();
+
+            expect(spy.saveState).toHaveBeenCalledTimes(1);
+            expect(state.cpu).toBe(savedCpu);
+            expect(spy.readRange).toHaveBeenCalledWith(RAM_BANK1_START, RAM_BANK1_SIZE);
+            expect(spy.readRange).toHaveBeenCalledWith(RAM_BANK2_START, RAM_BANK2_SIZE);
+            expect(state.ramBank1.data[0]).toBe(BANK1_MARKER);
+            expect(state.ramBank2.data[0]).toBe(BANK2_MARKER);
+        });
+
+        it('applyState writes CPU + both RAM banks into cpuEngine', () => {
+            const baseState = apple1.saveState();
+            const loadedCpu = makeCpuState(0x0200);
+            baseState.cpu = loadedCpu;
+            baseState.ramBank1.data.fill(0x11);
+            baseState.ramBank2.data.fill(0x22);
+
+            const spy = makeSpyEngine(makeCpuState(0));
+            apple1.cpuEngine = spy;
+
+            apple1.loadState(baseState);
+
+            expect(spy.loadState).toHaveBeenCalledWith(loadedCpu);
+            const writes = spy.writeRange.mock.calls;
+            expect(writes.find((c) => c[0] === RAM_BANK1_START)?.[1][0]).toBe(0x11);
+            expect(writes.find((c) => c[0] === RAM_BANK2_START)?.[1][0]).toBe(0x22);
+        });
+    });
+
+    describe('regression guard: pure-JS path (no cpuEngine)', () => {
+        it('saveEmulatorState still uses the JS cpu and produces a valid state', () => {
+            expect(apple1.cpuEngine).toBeUndefined();
+            const state = apple1.saveEmulatorState();
+            expect(state.cpu).toBeDefined();
+            expect(state.ram).toHaveLength(2);
+        });
+    });
+});

--- a/src/apple1/index.ts
+++ b/src/apple1/index.ts
@@ -79,9 +79,15 @@ class Apple1 extends VersionedStatefulComponentBase<Apple1State> implements IIns
      * @deprecated Use the new saveState() method that returns Apple1State
      */
     saveEmulatorState(): EmulatorState {
+        // Pull live RAM from the active engine first: under WASM the JS Bus copy
+        // is stale (WASM owns its own RAM), so serializing it directly would
+        // capture init-time RAM instead of what the machine is actually running.
+        this.syncRAMFromEngine();
         const state: EmulatorState = {
             ram: this.saveRAMState(),
-            cpu: this.cpu.saveState(),
+            // CPU must come from the active engine; this.cpu is the dormant JS
+            // CPU when WASM is active (see WorkerAPI.toDebug for the same lesson).
+            cpu: this.cpuEngine ? this.cpuEngine.saveState() : this.cpu.saveState(),
             pia: this.pia.saveState() as PIAState,
         };
 
@@ -97,7 +103,12 @@ class Apple1 extends VersionedStatefulComponentBase<Apple1State> implements IIns
      */
     loadEmulatorState(state: EmulatorState) {
         if (state.ram) this.loadRAMState(state.ram);
-        if (state.cpu) this.cpu.loadState(state.cpu);
+        // Load CPU into the active engine (DualEngine fans out to both engines);
+        // writing only this.cpu would leave the running WASM engine untouched.
+        if (state.cpu) {
+            if (this.cpuEngine) this.cpuEngine.loadState(state.cpu);
+            else this.cpu.loadState(state.cpu);
+        }
         if (state.pia) {
             // Convert old PIAState format to new PIA6820State format for migration
             const convertedPIAState = {
@@ -115,7 +126,48 @@ class Apple1 extends VersionedStatefulComponentBase<Apple1State> implements IIns
             this.pia.loadState(convertedPIAState);
         }
         if (state.video && typeof this.video.setState === 'function') this.video.setState(state.video);
+        // Mirror the restored JS-Bus RAM into the active engine's internal RAM so
+        // the WASM engine runs the loaded program rather than its init-time RAM.
+        this.syncRAMToEngine();
     }
+
+    /**
+     * RAM bank ranges that must stay mirrored between the JS Bus and the active
+     * engine's own RAM. The WASM engine owns a separate RAM copy seeded from the
+     * Bus only at init, so save/load has to bridge both banks explicitly.
+     */
+    private static readonly RAM_BANK_RANGES: ReadonlyArray<readonly [number, number]> = [
+        RAM_BANK1_ADDR,
+        RAM_BANK2_ADDR,
+    ];
+
+    /**
+     * Pull live RAM from the active engine into the JS Bus before serializing.
+     * No-op without a dual engine; idempotent when the JS engine is active
+     * (it already reads/writes the Bus directly).
+     */
+    private syncRAMFromEngine(): void {
+        if (!this.cpuEngine) return;
+        for (const [start, end] of Apple1.RAM_BANK_RANGES) {
+            const data = this.cpuEngine.readRange(start, end - start + 1);
+            for (let i = 0; i < data.length; i++) this.bus.write(start + i, data[i]);
+        }
+    }
+
+    /**
+     * Push the restored JS-Bus RAM into the active engine's internal RAM after
+     * loading. No-op without a dual engine.
+     */
+    private syncRAMToEngine(): void {
+        if (!this.cpuEngine) return;
+        for (const [start, end] of Apple1.RAM_BANK_RANGES) {
+            const len = end - start + 1;
+            const data = new Uint8Array(len);
+            for (let i = 0; i < len; i++) data[i] = this.bus.read(start + i);
+            this.cpuEngine.writeRange(start, data);
+        }
+    }
+
     /**
      * Save the state of all RAM banks.
      */
@@ -408,13 +460,17 @@ class Apple1 extends VersionedStatefulComponentBase<Apple1State> implements IIns
     saveState(options?: StateOptions): Apple1State {
         const opts = { includeDebugInfo: false, ...options };
 
+        // Capture the active engine's live RAM into the JS Bus before serializing.
+        this.syncRAMFromEngine();
+
         const state: Apple1State = {
             version: Apple1.STATE_VERSION,
             // System configuration
             cpuSpeedMHz: MHZ_CPU_SPEED,
             stepIntervalMs: STEP_INTERVAL,
-            // Component states
-            cpu: this.cpu.saveState(opts),
+            // Component states — CPU from the active engine (this.cpu is dormant
+            // under WASM); other components are engine-independent.
+            cpu: this.cpuEngine ? this.cpuEngine.saveState() : this.cpu.saveState(opts),
             clock: this.clock.saveState(opts),
             rom: this.rom.saveState(opts),
             ramBank1: this.ramBank1.saveState(opts),
@@ -454,8 +510,12 @@ class Apple1 extends VersionedStatefulComponentBase<Apple1State> implements IIns
             this.clock.stopLoop();
         }
 
-        // Load component states
-        this.cpu.loadState(finalState.cpu, opts);
+        // Load component states. CPU goes into the active engine (DualEngine
+        // fans out to both); this.cpu alone would leave a running WASM engine
+        // untouched. RAM banks restore the JS Bus, then syncRAMToEngine() mirrors
+        // them into the active engine's own RAM.
+        if (this.cpuEngine) this.cpuEngine.loadState(finalState.cpu);
+        else this.cpu.loadState(finalState.cpu, opts);
         this.clock.loadState(finalState.clock, opts);
         this.rom.loadState(finalState.rom, opts);
         this.ramBank1.loadState(finalState.ramBank1, opts);
@@ -466,6 +526,8 @@ class Apple1 extends VersionedStatefulComponentBase<Apple1State> implements IIns
         if (finalState.video && this.video && typeof this.video.setState === 'function') {
             this.video.setState(finalState.video);
         }
+
+        this.syncRAMToEngine();
 
         // Restart clock if it was running
         if (wasRunning) {

--- a/src/core/cpu-engines/DualEngine.ts
+++ b/src/core/cpu-engines/DualEngine.ts
@@ -20,6 +20,7 @@ import { JSEngine } from './JSEngine';
 import { WasmEngine } from './WasmEngine';
 import { isWasmSupported } from './wasm-loader';
 import { loggingService } from '../../services/LoggingService';
+import { RAM_BANK1_START, RAM_BANK1_END, RAM_BANK2_START, RAM_BANK2_END } from '../constants/memory';
 
 /**
  * Engine switch reason types
@@ -339,11 +340,20 @@ export class DualEngine implements ICPUEngine {
             // Ensure target engine is ready
             await newEngine.ensureReady();
 
-            // Synchronize RAM contents from source to target engine
-            // Apple 1 has 4KB RAM at $0000-$0FFF
-            const ramData = this.activeEngine.readRange(0x0000, 0x1000);
-            newEngine.writeRange(0x0000, ramData);
-            loggingService.info('DualEngine', `Synchronized ${ramData.length} bytes of RAM to ${targetEngine} engine`);
+            // Synchronize RAM contents from source to target engine for BOTH
+            // banks: bank 1 ($0000-$0FFF) and bank 2 ($E000-$EFFF, Integer BASIC).
+            // Syncing only bank 1 would drop bank-2 RAM on an engine switch.
+            const ramRanges: ReadonlyArray<readonly [number, number]> = [
+                [RAM_BANK1_START, RAM_BANK1_END],
+                [RAM_BANK2_START, RAM_BANK2_END],
+            ];
+            let syncedBytes = 0;
+            for (const [start, end] of ramRanges) {
+                const ramData = this.activeEngine.readRange(start, end - start + 1);
+                newEngine.writeRange(start, ramData);
+                syncedBytes += ramData.length;
+            }
+            loggingService.info('DualEngine', `Synchronized ${syncedBytes} bytes of RAM to ${targetEngine} engine`);
 
             // Load CPU state into target engine
             newEngine.loadState(currentState);

--- a/src/core/cpu-engines/__tests__/engine-parity.vitest.test.ts
+++ b/src/core/cpu-engines/__tests__/engine-parity.vitest.test.ts
@@ -489,5 +489,34 @@ describe.skipIf(!wasmRuntimeAvailable)('CPU Engine Parity Tests', () => {
             unsubscribe();
             dualEngine.cleanup();
         });
+
+        it('switchEngine syncs RAM for BOTH banks (bank 1 and bank 2)', async () => {
+            if (!wasmEngine) {
+                throw new Error('WASM engine expected but failed to initialize');
+            }
+
+            const dualEngine = new DualEngine(bus, 'JS');
+            await dualEngine.initialize();
+
+            // Diverge the engines: write only to the JS-backed Bus (the active
+            // JS engine reads the Bus; the WASM engine keeps its own RAM copy).
+            // switchEngine must then copy BOTH banks into WASM — the old code
+            // synced only bank 1, silently dropping bank 2 ($E000, Integer BASIC).
+            bus.write(0x0000, 0xa1); // bank 1 start
+            bus.write(0x0fff, 0xa2); // bank 1 end
+            bus.write(0xe000, 0xb1); // bank 2 start
+            bus.write(0xefff, 0xb2); // bank 2 end
+
+            await dualEngine.switchEngine('WASM');
+            expect(dualEngine.engineType).toBe('WASM');
+
+            // The now-active WASM engine must see both banks, read from its own RAM.
+            expect(dualEngine.read(0x0000)).toBe(0xa1);
+            expect(dualEngine.read(0x0fff)).toBe(0xa2);
+            expect(dualEngine.read(0xe000)).toBe(0xb1);
+            expect(dualEngine.read(0xefff)).toBe(0xb2);
+
+            dualEngine.cleanup();
+        });
     });
 });

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '4.50.0';
+export const APP_VERSION = '4.50.1';


### PR DESCRIPTION
## Problem

Loading a saved state did nothing when the **WASM engine** was active (it worked with JS), and states saved while WASM was active were themselves invalid. Both symptoms share one root cause.

`Apple1.this.cpu` is the **JS engine's** `CPU6502` — dormant when WASM is the active engine. The save/load path read/wrote `this.cpu` and the JS-side RAM banks directly, bypassing the `DualEngine`/WASM engine. The WASM engine owns a **separate** Rust-side RAM that's mirrored from the JS Bus only once at init. So under WASM:

- **Load** wrote registers into the idle JS CPU and restored only JS-Bus RAM → the running WASM engine never saw it.
- **Save** read stale JS registers + stale JS-Bus RAM → the snapshot didn't reflect what WASM was running.

The codebase already learned this exact "JS CPU is dormant under WASM" lesson for the debugger view (`WorkerAPI.ts` routes `toDebug()` through the active engine); save/load was simply never updated.

## Changes

- **`src/apple1/index.ts`** — route CPU save/load through `this.cpuEngine` (active engine; `DualEngine` fans out to both), and add `syncRAMFromEngine`/`syncRAMToEngine` to mirror **both** RAM banks at the save/load boundary. Applied to the live (deprecated) and versioned state paths.
- **`src/core/cpu-engines/DualEngine.ts`** — `switchEngine` now syncs **both** banks (`$0000-$0FFF` *and* `$E000-$EFFF`/Integer BASIC), not just bank 1.
- **Tests** — new CI spy-engine test for the routing (no WASM needed); new browser parity test for the bank-2 switch sync.
- **`src/version.ts`** — `4.50.0` → `4.50.1`.

## Verification

- `yarn test:ci` green (758 passed; 20 WASM tests skipped in CI by design — they need a browser).
- Real-WASM in-browser run confirmed: save-reads-WASM, load-reaches-WASM (registers + both RAM banks), and both-bank `switchEngine` sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed save and load functionality to correctly synchronize both memory banks and CPU state across different execution engines.
  * Improved memory synchronization when switching between JavaScript and WASM engines.
  * Resolved regression where engine state was not properly synchronized during save/load operations.

* **Chores**
  * Version bump to 4.50.1

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stid/Apple1JS/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->