### PR TITLE
chore: Tailwind v4 cleanup — drop cssnano + tokenize hardcoded colors

### DIFF
--- a/docs/active/consolidated_roadmap.md
+++ b/docs/active/consolidated_roadmap.md
@@ -72,7 +72,7 @@ These items improve core functionality without significant regression risk.
 src/core/cpu6502/
 ├── types.ts        # Shared interfaces and types
 ├── opcodes.ts      # Opcode table (256 entries)
-├── addressing.ts   # Addressing mode implementations  
+├── addressing.ts   # Addressing mode implementations
 ├── instructions.ts # Instruction implementations
 ├── debug.ts        # Debugging functionality
 ├── core.ts         # Main CPU class
@@ -93,14 +93,14 @@ src/core/cpu6502/
 
 - ✅ Analyzed existing worker state sync patterns across components
 - ✅ Created generic `useWorkerState<T>` hook with:
-  - Polling and subscription support
-  - Optimistic updates
-  - Error handling with custom handlers
-  - Transform functions for data processing
-  - Caching capabilities
+    - Polling and subscription support
+    - Optimistic updates
+    - Error handling with custom handlers
+    - Transform functions for data processing
+    - Caching capabilities
 - ✅ Created specialized hooks using `useWorkerState`:
-  - `useWorkerDebugInfo` - Adaptive polling based on pause state
-  - `useWorkerBreakpoints` - Helper functions for breakpoint management
+    - `useWorkerDebugInfo` - Adaptive polling based on pause state
+    - `useWorkerBreakpoints` - Helper functions for breakpoint management
 - ✅ Fixed duplicate CPU type definitions (moved to `core/cpu6502/types.ts`)
 - ✅ All tests passing (626 passed, 0 skipped)
 - ✅ App running successfully with no regressions
@@ -216,7 +216,7 @@ These enhance functionality with moderate complexity and risk.
 **Files to Update**:
 
 - WorkerCommunicationService.ts
-- StatePersistenceService.ts  
+- StatePersistenceService.ts
 - Error.tsx
 - errors.ts
 
@@ -317,13 +317,6 @@ These are nice-to-have improvements with minimal risk.
 - Rapid changes could cause flickering
 - Add debouncing to externalAddress
 
-#### Tailwind v4 follow-ups
-
-- Drop `cssnano` — redundant under v4 (`@tailwindcss/postcss` + Vite both minify CSS; it was
-  dead even on v3 via a stale `.postcssrc` shadow). One-line removal + dep drop.
-- Token-compliance for the `bg-black/*` / `text-gray-500` usages the v4 renames surfaced —
-  tracked under Component Color Standardization (#16).
-
 ---
 
 ### 16. Documentation & Standards
@@ -346,9 +339,12 @@ These are nice-to-have improvements with minimal risk.
 
 - Audit remaining hardcoded colors
 - Update to use design tokens
-- Known sites: `bg-black/40`, `bg-black/20` (~10 uses) and `!text-gray-500` (`UNMAPPED`
-  dimming). Grays map to `text-text-tertiary` (#6B7280); the translucent blacks need a new
-  `surface-translucent` token decision. (Surfaced by CodeRabbit on PR #179.)
+- ✅ Done (D-007): translucent blacks → `surface.sunken` (`bg-surface-sunken/{40,20}`), unmapped
+  `!text-gray-500` → `text-text-tertiary!`, and the dead `surface.hover`/`text.disabled` tokens
+  repaired.
+- Remaining (deferred): error reds in `Error.tsx` / `AppContent.tsx` "not connected" messages
+  (→ `error` token), `text-black` contrast text on accent backgrounds, and `index.css` base-layer
+  defaults (`bg-black`, `text-gray-400`, `text-slate-500`).
 
 ---
 
@@ -380,6 +376,8 @@ These are nice-to-have improvements with minimal risk.
 
 From various documents:
 
+- ✅ Tailwind v4 cleanup — dropped redundant `cssnano`; tokenized hardcoded panel/unmapped colors
+    - repaired dead `surface.hover`/`text.disabled` tokens (D-007)
 - ✅ Tailwind CSS v3→v4 upgrade — compat-first via `@config`, token SSOT preserved (PR #179)
 - ✅ Comlink Worker Migration (Phase 2 complete)
 - ✅ Jest to Vitest Migration (601 tests)

--- a/docs/lcd/DECISIONS.md
+++ b/docs/lcd/DECISIONS.md
@@ -6,9 +6,28 @@
 > one `superseded by D-NNN`. Work-item-local decisions live in that item's `JOURNAL.md`; mirror
 > here only the ones that outlive the work item.
 
-<!-- Next id: D-007 -->
+<!-- Next id: D-008 -->
 
 ---
+
+## D-007 · 2026-05-30 · Tailwind v4 follow-up: cssnano dropped; semantic alias tokens added
+
+- **Context:** Two tech-debt items parked by D-006 + a latent bug found while addressing them:
+  components referenced `bg-surface-hover` (7×) and `text-text-disabled` (11×), tokens that did
+  not exist in `tokens.ts`/the adapter, so those classes emitted **no CSS** (missing hover lift,
+  uncolored disabled text). The parity test only guards adapter→config, never component→token.
+- **Decision:** (1) Drop `cssnano` — `@tailwindcss/postcss` + Vite already minify CSS in production
+  (verified). (2) Repair the dead classes by **adding** the missing tokens rather than rewriting
+  ~18 call sites: `surface.hover` (#334155, alias of `tertiary`), `text.disabled` (#6B7280, alias
+  of `muted`). (3) Add `surface.sunken` (#000000) and replace hardcoded `bg-black/{40,20}` with
+  `bg-surface-sunken/{40,20}` (identical CSS via opacity modifier); map unmapped-cell
+  `text-gray-500!` → `text-text-tertiary!`.
+- **Alternatives rejected:** rewriting the 18 refs to existing tokens (`bg-surface-tertiary` /
+  `text-text-muted`) — more churn, discards the authors' semantic intent. Error-red mapping,
+  `text-black`, and `index.css` base defaults were **deferred** (out of this phase's scope). CRT
+  colors remain intentionally exempt (CLAUDE.md).
+- **Scope:** project-wide
+- **Status:** active
 
 ## D-006 · 2026-05-30 · Tailwind v4 adopted compat-first (`@config`); CSS-first `@theme` deferred
 
@@ -22,7 +41,7 @@
 - **Alternatives rejected:** the upgrade tool's CSS-first `@theme` inlining — hardcodes token
   values and orphans the adapter + parity test (a token-SSOT downgrade); `@tailwindcss/vite` —
   Rolldown plugin-hook friction under Vite 8. The **CSS-first `@theme` rewrite is deferred** as a
-  future modernization (re-architect `tokens.ts` to *emit* `@theme`, unifying Tailwind utilities
+  future modernization (re-architect `tokens.ts` to _emit_ `@theme`, unifying Tailwind utilities
   and runtime inline styles on one set of CSS variables) — not needed; we are fully on v4.
 - **Scope:** project-wide
 - **Status:** active
@@ -34,7 +53,7 @@
   `sendWorkerMessage(...)` with messages defined in `src/apple1/types/worker-messages.ts`.
 - **Alternatives rejected:** main-thread loop (janks UI); raw `postMessage` (untyped, error-prone).
 - **Scope:** project-wide
-- **Status:** active   <!-- detected at onboarding — confirm/edit -->
+- **Status:** active <!-- detected at onboarding — confirm/edit -->
 
 ## D-004 · 2026-05-28 · WASM build is speed-first
 
@@ -43,7 +62,7 @@
   this is what `yarn dev` ships. The old "<100 KB / 90 KB" size-first target is abandoned.
 - **Alternatives rejected:** size-first (<100 KB) — slower; not restored without approval.
 - **Scope:** project-wide
-- **Status:** active   <!-- detected at onboarding — confirm/edit -->
+- **Status:** active <!-- detected at onboarding — confirm/edit -->
 
 ## D-003 · 2026-05-28 · Dual-engine 6502 (TypeScript + Rust/WASM)
 
@@ -53,7 +72,7 @@
   fallback and parity oracle. Test both engines for every engine change.
 - **Alternatives rejected:** WASM-only (loses the readable reference + fallback); JS-only (~14× slower).
 - **Scope:** project-wide
-- **Status:** active   <!-- detected at onboarding — confirm/edit -->
+- **Status:** active <!-- detected at onboarding — confirm/edit -->
 
 ## D-002 · 2026-05-28 · Vitest as the test framework
 
@@ -62,7 +81,7 @@
   `src/**/*.vitest.{test,spec}.{js,jsx,ts,tsx}`, tests co-located under `__tests__/`.
 - **Alternatives rejected:** Jest (slower with Vite; extra config).
 - **Scope:** project-wide
-- **Status:** active   <!-- detected at onboarding — confirm/edit -->
+- **Status:** active <!-- detected at onboarding — confirm/edit -->
 
 ## D-001 · 2026-05-28 · Yarn (classic) as the package manager
 
@@ -70,7 +89,7 @@
 - **Decision:** Use Yarn (`yarn.lock`) for dependency management and script running.
 - **Alternatives rejected:** npm / pnpm — no migration reason.
 - **Scope:** project-wide
-- **Status:** active   <!-- detected at onboarding — confirm/edit -->
+- **Status:** active <!-- detected at onboarding — confirm/edit -->
 
 ---
 

--- a/docs/lcd/work/tw4-cleanup/JOURNAL.md
+++ b/docs/lcd/work/tw4-cleanup/JOURNAL.md
@@ -10,17 +10,17 @@
 
 - **Lane:** Standard
 - **Goal:** Tailwind v4 follow-ups — drop redundant cssnano + tokenize hardcoded panel/disabled colors and repair the dead `surface.hover`/`text.disabled` tokens.
-- **Next action:** Drop cssnano (postcss.config.js + package.json), `yarn install`, verify `yarn build` CSS still minified.
-- **Branch:** chore/tw4-cleanup · **Updated:** 2026-05-30 12:44
+- **Next action:** Commit docs; push branch; open PR. (All code + verification done.)
+- **Branch:** chore/tw4-cleanup · **Updated:** 2026-05-30 12:50
 
 ## STEPS
 
 - [x] S1 — Branch `chore/tw4-cleanup` + bump version 4.51.1 → 4.51.2
-- [ ] S2 — Drop cssnano (postcss.config.js, package.json, yarn.lock); verify build minified ← next
-- [ ] S3 — TDD: add parity assertions (red) → add `surface.hover/sunken` + `text.disabled` to tokens.ts + adapter (green)
-- [ ] S4 — Swap `bg-black/{40,20}` → `bg-surface-sunken/{40,20}` + `text-gray-500!` → `text-text-tertiary!`
-- [ ] S5 — Gate (`yarn lint && type-check && test:ci`) + browser verify (hover/disabled/panels)
-- [ ] S6 — Update JOURNAL/DECISIONS/roadmap; push; open PR
+- [x] S2 — Drop cssnano (postcss.config.js, package.json, yarn.lock); build CSS confirmed minified (commit 69a2ad2)
+- [x] S3 — TDD: parity assertions red → added `surface.hover/sunken` + `text.disabled` to tokens.ts + adapter, green (commit 858e877)
+- [x] S4 — Swapped `bg-black/{40,20}` → `bg-surface-sunken/{40,20}` (×10) + `text-gray-500!` → `text-text-tertiary!` (commit 654ad40)
+- [x] S5 — Gate green (759 passed/20 skipped); verified via dist-CSS grep (dead utilities now emit correct values)
+- [ ] S6 — Commit docs (DECISIONS D-007 + roadmap); push; open PR ← next
 
 ## DECISIONS (this work-item)
 
@@ -44,9 +44,11 @@
 
 ## Acceptance criteria
 
-Internal CSS/build cleanup with a RENDER surface verified by browser, not formal ACs. The token
-parity test is the regression guard; the grep guards + visual checks are the surface verification.
+Internal CSS/build cleanup with a RENDER surface. The token parity test is the regression guard;
+the grep guards + dist-CSS inspection are the surface verification (see LOG for why dist-CSS grep
+is the stronger check than a screenshot here).
 
 ## LOG (append-only; not read on resume)
 
 - 2026-05-30 12:44 — Triage → Standard. Audit found documented items (translucent blacks, gray-500) + a latent bug: `bg-surface-hover` (7×) and `text-text-disabled` (11×) reference tokens absent from tokens.ts/adapter → emit no CSS. User approved scope B (docs + broken-token repair; error reds deferred). S1 done (branch + version 4.51.2).
+- 2026-05-30 12:50 — S2–S5 done. cssnano dropped (dist CSS confirmed minified without it). Tokens added TDD (red→green). 10 `bg-black/*` + 1 `text-gray-500!` swapped. Gate green (759/20). Verified via `dist` CSS grep: `bg-surface-hover{background-color:#334155}` and `text-text-disabled{color:#6b7280}` now EMIT (were absent — the build artifact was the bug report); `bg-surface-sunken/{40,20}` → `oklab(0% none none/.{4,2})` == old `bg-black/*`. Chose dist-CSS proof over a live browser session (deterministic + avoids the documented never-idle-emulator browser-verify hazards). Mirrored durable choices to DECISIONS D-007 + roadmap.

--- a/docs/lcd/work/tw4-cleanup/JOURNAL.md
+++ b/docs/lcd/work/tw4-cleanup/JOURNAL.md
@@ -10,7 +10,7 @@
 
 - **Lane:** Standard
 - **Goal:** Tailwind v4 follow-ups — drop redundant cssnano + tokenize hardcoded panel/disabled colors and repair the dead `surface.hover`/`text.disabled` tokens.
-- **Next action:** Commit docs; push branch; open PR. (All code + verification done.)
+- **Next action:** Done — PR #181 open (<https://github.com/stid/Apple1JS/pull/181>), awaiting review/merge.
 - **Branch:** chore/tw4-cleanup · **Updated:** 2026-05-30 12:50
 
 ## STEPS
@@ -20,7 +20,7 @@
 - [x] S3 — TDD: parity assertions red → added `surface.hover/sunken` + `text.disabled` to tokens.ts + adapter, green (commit 858e877)
 - [x] S4 — Swapped `bg-black/{40,20}` → `bg-surface-sunken/{40,20}` (×10) + `text-gray-500!` → `text-text-tertiary!` (commit 654ad40)
 - [x] S5 — Gate green (759 passed/20 skipped); verified via dist-CSS grep (dead utilities now emit correct values)
-- [ ] S6 — Commit docs (DECISIONS D-007 + roadmap); push; open PR ← next
+- [x] S6 — Committed docs (DECISIONS D-007 + roadmap); pushed; opened PR #181
 
 ## DECISIONS (this work-item)
 
@@ -38,7 +38,7 @@
 - `src/styles/tokens.ts`, `src/styles/tailwind-tokens.ts`, `src/styles/__tests__/token-tailwind-parity.vitest.test.ts`
 - `src/components/{Info,PaginatedTableView,StackViewer,MemoryViewerPaginated}.tsx`
 - `docs/lcd/DECISIONS.md`, `docs/active/consolidated_roadmap.md`
-  <!-- /lcd-resume -->
+      <!-- /lcd-resume -->
 
 ---
 

--- a/docs/lcd/work/tw4-cleanup/JOURNAL.md
+++ b/docs/lcd/work/tw4-cleanup/JOURNAL.md
@@ -1,0 +1,52 @@
+# JOURNAL — tw4-cleanup
+
+> **The resume anchor.** The block between the `lcd-resume:v1` markers below is the _entire_
+> cold-start payload. `/stid-lcd:resume` reads MAP.md + this block + DECISIONS headers and nothing
+> else. Keep NOW and STEPS current as you work. Everything below the `---` is history/detail.
+
+<!-- lcd-resume:v1 -->
+
+## NOW
+
+- **Lane:** Standard
+- **Goal:** Tailwind v4 follow-ups — drop redundant cssnano + tokenize hardcoded panel/disabled colors and repair the dead `surface.hover`/`text.disabled` tokens.
+- **Next action:** Drop cssnano (postcss.config.js + package.json), `yarn install`, verify `yarn build` CSS still minified.
+- **Branch:** chore/tw4-cleanup · **Updated:** 2026-05-30 12:44
+
+## STEPS
+
+- [x] S1 — Branch `chore/tw4-cleanup` + bump version 4.51.1 → 4.51.2
+- [ ] S2 — Drop cssnano (postcss.config.js, package.json, yarn.lock); verify build minified ← next
+- [ ] S3 — TDD: add parity assertions (red) → add `surface.hover/sunken` + `text.disabled` to tokens.ts + adapter (green)
+- [ ] S4 — Swap `bg-black/{40,20}` → `bg-surface-sunken/{40,20}` + `text-gray-500!` → `text-text-tertiary!`
+- [ ] S5 — Gate (`yarn lint && type-check && test:ci`) + browser verify (hover/disabled/panels)
+- [ ] S6 — Update JOURNAL/DECISIONS/roadmap; push; open PR
+
+## DECISIONS (this work-item)
+
+- Repair dead tokens by _adding_ `surface.hover`/`text.disabled` (not rewriting ~15 refs to existing tokens) — preserves authors' semantic intent, fewer edits.
+- One `surface.sunken: #000000` + Tailwind v4 opacity modifiers reproduce `bg-black/40` and `/20` at identical CSS.
+- Scope B: error reds, `text-black`, `index.css` base defaults deferred; CRT exempt.
+
+## OPEN QUESTIONS
+
+- none
+
+## EDIT BOUNDARY (paths this work may touch)
+
+- `postcss.config.js`, `package.json`, `yarn.lock`, `src/version.ts`
+- `src/styles/tokens.ts`, `src/styles/tailwind-tokens.ts`, `src/styles/__tests__/token-tailwind-parity.vitest.test.ts`
+- `src/components/{Info,PaginatedTableView,StackViewer,MemoryViewerPaginated}.tsx`
+- `docs/lcd/DECISIONS.md`, `docs/active/consolidated_roadmap.md`
+  <!-- /lcd-resume -->
+
+---
+
+## Acceptance criteria
+
+Internal CSS/build cleanup with a RENDER surface verified by browser, not formal ACs. The token
+parity test is the regression guard; the grep guards + visual checks are the surface verification.
+
+## LOG (append-only; not read on resume)
+
+- 2026-05-30 12:44 — Triage → Standard. Audit found documented items (translucent blacks, gray-500) + a latent bug: `bg-surface-hover` (7×) and `text-text-disabled` (11×) reference tokens absent from tokens.ts/adapter → emit no CSS. User approved scope B (docs + broken-token repair; error reds deferred). S1 done (branch + version 4.51.2).

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
         "@typescript-eslint/parser": "^8.36.0",
         "@vitejs/plugin-react": "6.0.2",
         "@vitest/ui": "^4.1.7",
-        "cssnano": "^8.0.1",
         "eslint": "^9.39.4",
         "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-jest": "^29.0.1",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,5 @@
 export default {
     plugins: {
         '@tailwindcss/postcss': {},
-        ...(process.env.NODE_ENV === 'production' ? { cssnano: {} } : {}),
     },
 };

--- a/src/components/Info.tsx
+++ b/src/components/Info.tsx
@@ -5,7 +5,10 @@ const StartInstructions = () => (
             FIRST START / RESET
         </h3>
         <p className="text-text-primary text-sm">
-            Press <span className="font-mono bg-black/40 px-sm py-1 rounded-sm text-data-value border border-border-subtle">TAB</span>
+            Press{' '}
+            <span className="font-mono bg-surface-sunken/40 px-sm py-1 rounded-sm text-data-value border border-border-subtle">
+                TAB
+            </span>
         </p>
     </section>
 );
@@ -16,7 +19,7 @@ const TestProgram = () => (
             <span className="mr-2">🧪</span>
             TEST PROGRAM
         </h3>
-        <pre className="bg-black/40 text-data-value rounded-sm p-sm text-xs font-mono leading-relaxed whitespace-pre border border-border-subtle">{`0:A9 0 AA 20 EF FF E8 8A 4C 2 0
+        <pre className="bg-surface-sunken/40 text-data-value rounded-sm p-sm text-xs font-mono leading-relaxed whitespace-pre border border-border-subtle">{`0:A9 0 AA 20 EF FF E8 8A 4C 2 0
 0
 R`}</pre>
     </section>
@@ -28,7 +31,7 @@ const BasicProgram = () => (
             <span className="mr-2">💻</span>
             BASIC
         </h3>
-        <pre className="bg-black/40 text-data-value rounded-sm p-sm text-xs font-mono leading-relaxed whitespace-pre border border-border-subtle">{`E000R
+        <pre className="bg-surface-sunken/40 text-data-value rounded-sm p-sm text-xs font-mono leading-relaxed whitespace-pre border border-border-subtle">{`E000R
 10 PRINT "HELLO WORLD!"
 20 GOTO 10
 RUN`}</pre>
@@ -41,10 +44,9 @@ const AnniversaryInfo = () => (
             <span className="mr-2">🎉</span>
             APPLE 30th ANNIVERSARY
         </h3>
-        <pre className="bg-black/40 text-data-value rounded-sm p-sm text-xs font-mono inline-block whitespace-pre border border-border-subtle">{`280R`}</pre>
+        <pre className="bg-surface-sunken/40 text-data-value rounded-sm p-sm text-xs font-mono inline-block whitespace-pre border border-border-subtle">{`280R`}</pre>
     </section>
 );
-
 
 const MemoryAddresses = () => (
     <section className="bg-surface-primary rounded-lg p-md border border-border-primary mb-sm">
@@ -52,7 +54,7 @@ const MemoryAddresses = () => (
             <span className="mr-2">🔍</span>
             LIST MEMORY ADDRESS
         </h3>
-        <pre className="bg-black/40 text-data-address rounded-sm p-sm text-xs font-mono inline-block whitespace-pre border border-border-subtle">{`0.FF`}</pre>
+        <pre className="bg-surface-sunken/40 text-data-address rounded-sm p-sm text-xs font-mono inline-block whitespace-pre border border-border-subtle">{`0.FF`}</pre>
     </section>
 );
 

--- a/src/components/MemoryViewerPaginated.tsx
+++ b/src/components/MemoryViewerPaginated.tsx
@@ -35,136 +35,143 @@ interface MemoryRowProps {
 
 // Memoized memory row component - only re-renders if its props change
 /* eslint-disable react/prop-types */
-const MemoryRow = memo<MemoryRowProps>(({ 
-    baseAddr, 
-    bytesPerRow, 
-    memoryData, 
-    editingCell, 
-    editValue, 
-    workerManager,
-    maxAddress,
-    memoryMap,
-    onCellClick,
-    onCellEdit,
-    onCellEditComplete,
-    onKeyDown
-}) => {
-    // Helper to find memory region for an address
-    const getMemoryRegion = (address: number): MemoryRegion | undefined => {
-        return memoryMap.find(region => address >= region.start && address <= region.end);
-    };
-    if (baseAddr > maxAddress) return null;
-    
-    const cells = [];
-    const asciiChars = [];
-
-    // Address column
-    cells.push(
-        <td key="addr" className="px-2 py-1 font-mono text-xs whitespace-nowrap">
-            <AddressLink
-                address={baseAddr}
-                format="hex4"
-                prefix=""
-                workerManager={workerManager}
-                showContextMenu={true}
-                showRunToCursor={true}
-                className="font-mono text-xs"
-            />
-            <span className="text-data-address">:</span>
-        </td>
-    );
-
-    // Hex bytes
-    for (let i = 0; i < bytesPerRow; i++) {
-        const addr = baseAddr + i;
-        if (addr > maxAddress) {
-            cells.push(<td key={`hex-${i}`} className="px-2 py-1"></td>);
-            asciiChars.push(' ');
-            continue;
-        }
-        
-        const addrKey = `0x${Formatters.hex(addr, 4)}`;
-        const value = memoryData[addrKey] ?? 0;
-        const isEditing = editingCell === addr;
-        const region = getMemoryRegion(addr);
-        
-        // Determine cell styling based on memory type
-        const getCellStyle = () => {
-            if (!region) return '';
-            switch (region.type) {
-                case 'ROM':
-                    return 'bg-semantic-error/10 cursor-not-allowed';
-                case 'RAM':
-                    return '';
-                case 'IO':
-                    return 'bg-semantic-info/10';
-                case 'UNMAPPED':
-                    return 'bg-surface-tertiary/50 cursor-not-allowed';
-                default:
-                    return '';
-            }
+const MemoryRow = memo<MemoryRowProps>(
+    ({
+        baseAddr,
+        bytesPerRow,
+        memoryData,
+        editingCell,
+        editValue,
+        workerManager,
+        maxAddress,
+        memoryMap,
+        onCellClick,
+        onCellEdit,
+        onCellEditComplete,
+        onKeyDown,
+    }) => {
+        // Helper to find memory region for an address
+        const getMemoryRegion = (address: number): MemoryRegion | undefined => {
+            return memoryMap.find((region) => address >= region.start && address <= region.end);
         };
-        
-        const isWritable = region?.writable ?? false;
+        if (baseAddr > maxAddress) return null;
 
+        const cells = [];
+        const asciiChars = [];
+
+        // Address column
         cells.push(
-            <td 
-                key={`hex-${i}`} 
-                className={`px-2 py-1 text-center ${isWritable ? 'cursor-pointer hover:bg-surface-hover' : ''} ${getCellStyle()}`}
-                onClick={() => isWritable && onCellClick(addr)}
-                title={region ? `${region.type}: ${region.description}` : ''}
-            >
-                {isEditing ? (
-                    <input
-                        type="text"
-                        value={editValue}
-                        onChange={onCellEdit}
-                        onBlur={onCellEditComplete}
-                        onKeyDown={onKeyDown}
-                        onFocus={(e) => e.target.select()}
-                        className="w-6 text-center bg-info text-black font-mono text-xs rounded-sm"
-                        autoFocus
-                    />
-                ) : (
-                    <span className={`font-mono text-xs ${!region || region.type === 'UNMAPPED' ? 'text-gray-500!' : 'text-data-value'}`}>
-                        {Formatters.hex(value, 2)}
-                    </span>
-                )}
-            </td>
+            <td key="addr" className="px-2 py-1 font-mono text-xs whitespace-nowrap">
+                <AddressLink
+                    address={baseAddr}
+                    format="hex4"
+                    prefix=""
+                    workerManager={workerManager}
+                    showContextMenu={true}
+                    showRunToCursor={true}
+                    className="font-mono text-xs"
+                />
+                <span className="text-data-address">:</span>
+            </td>,
         );
 
-        // ASCII representation
-        const ascii = (value >= 32 && value <= 126) ? String.fromCharCode(value) : '.';
-        asciiChars.push(ascii);
-    }
+        // Hex bytes
+        for (let i = 0; i < bytesPerRow; i++) {
+            const addr = baseAddr + i;
+            if (addr > maxAddress) {
+                cells.push(<td key={`hex-${i}`} className="px-2 py-1"></td>);
+                asciiChars.push(' ');
+                continue;
+            }
 
-    // ASCII column
-    cells.push(
-        <td key="ascii" className="px-3 py-1 text-text-secondary font-mono text-xs border-l border-border-subtle whitespace-nowrap">
-            {asciiChars.join('')}
-        </td>
-    );
+            const addrKey = `0x${Formatters.hex(addr, 4)}`;
+            const value = memoryData[addrKey] ?? 0;
+            const isEditing = editingCell === addr;
+            const region = getMemoryRegion(addr);
 
-    return (
-        <tr className="border-b border-border-subtle hover:bg-surface-hover/50" style={{ height: '24px' }}>
-            {cells}
-        </tr>
-    );
-});
+            // Determine cell styling based on memory type
+            const getCellStyle = () => {
+                if (!region) return '';
+                switch (region.type) {
+                    case 'ROM':
+                        return 'bg-semantic-error/10 cursor-not-allowed';
+                    case 'RAM':
+                        return '';
+                    case 'IO':
+                        return 'bg-semantic-info/10';
+                    case 'UNMAPPED':
+                        return 'bg-surface-tertiary/50 cursor-not-allowed';
+                    default:
+                        return '';
+                }
+            };
+
+            const isWritable = region?.writable ?? false;
+
+            cells.push(
+                <td
+                    key={`hex-${i}`}
+                    className={`px-2 py-1 text-center ${isWritable ? 'cursor-pointer hover:bg-surface-hover' : ''} ${getCellStyle()}`}
+                    onClick={() => isWritable && onCellClick(addr)}
+                    title={region ? `${region.type}: ${region.description}` : ''}
+                >
+                    {isEditing ? (
+                        <input
+                            type="text"
+                            value={editValue}
+                            onChange={onCellEdit}
+                            onBlur={onCellEditComplete}
+                            onKeyDown={onKeyDown}
+                            onFocus={(e) => e.target.select()}
+                            className="w-6 text-center bg-info text-black font-mono text-xs rounded-sm"
+                            autoFocus
+                        />
+                    ) : (
+                        <span
+                            className={`font-mono text-xs ${!region || region.type === 'UNMAPPED' ? 'text-text-tertiary!' : 'text-data-value'}`}
+                        >
+                            {Formatters.hex(value, 2)}
+                        </span>
+                    )}
+                </td>,
+            );
+
+            // ASCII representation
+            const ascii = value >= 32 && value <= 126 ? String.fromCharCode(value) : '.';
+            asciiChars.push(ascii);
+        }
+
+        // ASCII column
+        cells.push(
+            <td
+                key="ascii"
+                className="px-3 py-1 text-text-secondary font-mono text-xs border-l border-border-subtle whitespace-nowrap"
+            >
+                {asciiChars.join('')}
+            </td>,
+        );
+
+        return (
+            <tr className="border-b border-border-subtle hover:bg-surface-hover/50" style={{ height: '24px' }}>
+                {cells}
+            </tr>
+        );
+    },
+);
 /* eslint-enable react/prop-types */
 
 MemoryRow.displayName = 'MemoryRow';
 
-const MemoryViewerPaginated: React.FC<MemoryViewerProps> = ({ 
-    workerManager, 
+const MemoryViewerPaginated: React.FC<MemoryViewerProps> = ({
+    workerManager,
     startAddress = 0x0000,
     currentAddress: externalAddress,
-    onAddressChange
+    onAddressChange,
 }) => {
     const [memoryData, setMemoryData] = useState<MemoryData>({});
     const { currentAddress, navigateInternal } = useNavigableComponent({
         initialAddress: externalAddress ?? startAddress,
-        ...(onAddressChange !== undefined && { onAddressChange })
+        ...(onAddressChange !== undefined && { onAddressChange }),
     });
     const [addressInput, setAddressInput] = useState(Formatters.hex(externalAddress ?? startAddress, 4));
     const [editingCell, setEditingCell] = useState<number | null>(null);
@@ -176,11 +183,11 @@ const MemoryViewerPaginated: React.FC<MemoryViewerProps> = ({
     const contentRef = useRef<HTMLDivElement>(null);
     const [visibleRows, setVisibleRows] = useState(15);
     const { safeSetTimeout } = useUnmountSafe();
-    
+
     // Fetch memory map on mount
     useEffect(() => {
         if (!workerManager) return;
-        
+
         const fetchMemoryMap = async () => {
             try {
                 const mapData = await workerManager.getMemoryMap();
@@ -191,33 +198,33 @@ const MemoryViewerPaginated: React.FC<MemoryViewerProps> = ({
                 console.error('Error fetching memory map:', error);
             }
         };
-        
+
         fetchMemoryMap();
     }, [workerManager]);
-    
+
     // Calculate visible rows based on actual container
     useEffect(() => {
         const calculateRows = () => {
             if (!contentRef.current) return;
-            
+
             const content = contentRef.current;
-            
+
             // Wait a frame for layout to complete
             window.requestAnimationFrame(() => {
                 const table = content.querySelector('table');
                 if (!table) return;
-                
+
                 const thead = table.querySelector('thead') as HTMLElement;
                 if (!thead) return;
-                
+
                 // Get actual measurements
                 const contentRect = content.getBoundingClientRect();
                 const theadRect = thead.getBoundingClientRect();
-                
+
                 // Get a sample row to measure actual height
                 const tbody = table.querySelector('tbody');
                 let actualRowHeight = 25;
-                
+
                 if (tbody) {
                     const firstRow = tbody.querySelector('tr');
                     if (firstRow) {
@@ -225,42 +232,42 @@ const MemoryViewerPaginated: React.FC<MemoryViewerProps> = ({
                         actualRowHeight = rowRect.height;
                     }
                 }
-                
+
                 // Available height for tbody
                 const availableHeight = contentRect.height - (theadRect.height || 28);
-                
+
                 // Calculate rows with actual measured height
                 const possibleRows = Math.floor(availableHeight / actualRowHeight);
-                
+
                 // Set visible rows with minimum of 3
                 setVisibleRows(Math.max(3, possibleRows));
             });
         };
-        
+
         // Initial calculation
         const timer = setTimeout(calculateRows, 150);
-        
+
         // Recalculate on resize
         const resizeObserver = new ResizeObserver(() => {
             calculateRows();
         });
-        
+
         if (contentRef.current) {
             resizeObserver.observe(contentRef.current);
         }
-        
+
         window.addEventListener('resize', calculateRows);
-        
+
         return () => {
             clearTimeout(timer);
             resizeObserver.disconnect();
             window.removeEventListener('resize', calculateRows);
         };
     }, []);
-    
+
     const effectiveRows = visibleRows;
     const size = effectiveRows * bytesPerRow;
-    
+
     // Update address input when currentAddress changes
     useEffect(() => {
         setAddressInput(Formatters.hex(currentAddress, 4));
@@ -277,23 +284,23 @@ const MemoryViewerPaginated: React.FC<MemoryViewerProps> = ({
                         const addr = currentAddress + index;
                         newMemData[`0x${Formatters.hex(addr, 4)}`] = value;
                     });
-                    
+
                     // Only update state if memory actually changed
-                    setMemoryData(prevData => {
+                    setMemoryData((prevData) => {
                         // Quick check: if sizes differ, data definitely changed
                         const prevKeys = Object.keys(prevData);
                         const newKeys = Object.keys(newMemData);
                         if (prevKeys.length !== newKeys.length) {
                             return newMemData;
                         }
-                        
+
                         // Check if any values changed
                         for (const key of newKeys) {
                             if (prevData[key] !== newMemData[key]) {
                                 return newMemData;
                             }
                         }
-                        
+
                         // No changes, return previous data to avoid re-render
                         return prevData;
                     });
@@ -320,9 +327,9 @@ const MemoryViewerPaginated: React.FC<MemoryViewerProps> = ({
     const handleAddressSubmit = (e: React.KeyboardEvent<HTMLInputElement>) => {
         if (e.key === 'Enter') {
             const addr = parseInt(addressInput || '0', 16);
-            if (!isNaN(addr) && addr >= 0 && addr <= 0xFFFF) {
+            if (!isNaN(addr) && addr >= 0 && addr <= 0xffff) {
                 // Ensure the address won't cause the view to exceed memory bounds
-                const maxStartAddr = Math.max(0, 0xFFFF - size + 1);
+                const maxStartAddr = Math.max(0, 0xffff - size + 1);
                 const validAddr = Math.min(addr, maxStartAddr);
                 navigateInternal(validAddr);
             }
@@ -336,11 +343,11 @@ const MemoryViewerPaginated: React.FC<MemoryViewerProps> = ({
 
     const navigateDown = useCallback(() => {
         // Calculate the maximum valid starting address
-        const maxStartAddr = Math.max(0, 0xFFFF - size + 1);
-        
+        const maxStartAddr = Math.max(0, 0xffff - size + 1);
+
         // Calculate next address
         const nextAddr = currentAddress + size;
-        
+
         // Ensure we don't go past the maximum valid start address
         if (nextAddr > maxStartAddr) {
             // Snap to the last valid page that shows up to 0xFFFF
@@ -354,7 +361,7 @@ const MemoryViewerPaginated: React.FC<MemoryViewerProps> = ({
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
             if (editingCell !== null) return; // Don't navigate while editing
-            
+
             if (e.key === 'ArrowUp') {
                 e.preventDefault();
                 navigateUp();
@@ -368,11 +375,14 @@ const MemoryViewerPaginated: React.FC<MemoryViewerProps> = ({
         return () => window.removeEventListener('keydown', handleKeyDown);
     }, [editingCell, navigateUp, navigateDown]);
 
-    const handleCellClick = useCallback((address: number) => {
-        setEditingCell(address);
-        const value = memoryData[`0x${Formatters.hex(address, 4)}`] || 0;
-        setEditValue(Formatters.hex(value, 2));
-    }, [memoryData]);
+    const handleCellClick = useCallback(
+        (address: number) => {
+            setEditingCell(address);
+            const value = memoryData[`0x${Formatters.hex(address, 4)}`] || 0;
+            setEditValue(Formatters.hex(value, 2));
+        },
+        [memoryData],
+    );
 
     const handleCellEdit = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
         const value = e.target.value.replace(/[^0-9A-Fa-f]/g, '').toUpperCase();
@@ -393,56 +403,76 @@ const MemoryViewerPaginated: React.FC<MemoryViewerProps> = ({
         setEditValue('');
     }, [editingCell, editValue, workerManager]);
 
-    const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-        if (e.key === 'Enter') {
-            handleCellEditComplete();
-        } else if (e.key === 'Tab') {
-            e.preventDefault(); // Prevent default tab behavior
-            handleCellEditComplete();
-            
-            // Move to next cell if not at the end
-            if (editingCell !== null) {
-                const maxAddress = currentAddress + size - 1;
-                const nextAddress = editingCell + 1;
-                
-                if (nextAddress <= maxAddress && nextAddress <= 0xFFFF) {
-                    // Small delay to ensure the current edit is processed
-                    safeSetTimeout(() => {
-                        handleCellClick(nextAddress);
-                    }, 50);
-                }
-            }
-        } else if (e.key === 'Escape') {
-            setEditingCell(null);
-            setEditValue('');
-        }
-    }, [editingCell, currentAddress, size, handleCellEditComplete, handleCellClick, safeSetTimeout]);
+    const handleKeyDown = useCallback(
+        (e: React.KeyboardEvent) => {
+            if (e.key === 'Enter') {
+                handleCellEditComplete();
+            } else if (e.key === 'Tab') {
+                e.preventDefault(); // Prevent default tab behavior
+                handleCellEditComplete();
 
-    const renderMemoryRow = useCallback((rowIndex: number) => {
-        const baseAddr = currentAddress + (rowIndex * bytesPerRow);
-        
-        return (
-            <MemoryRow
-                key={baseAddr}
-                baseAddr={baseAddr}
-                bytesPerRow={bytesPerRow}
-                memoryData={memoryData}
-                editingCell={editingCell}
-                editValue={editValue}
-                workerManager={workerManager}
-                maxAddress={0xFFFF}
-                memoryMap={memoryMap}
-                onCellClick={handleCellClick}
-                onCellEdit={handleCellEdit}
-                onCellEditComplete={handleCellEditComplete}
-                onKeyDown={handleKeyDown}
-            />
-        );
-    }, [currentAddress, bytesPerRow, memoryData, editingCell, editValue, workerManager, memoryMap,
-        handleCellClick, handleCellEdit, handleCellEditComplete, handleKeyDown]);
+                // Move to next cell if not at the end
+                if (editingCell !== null) {
+                    const maxAddress = currentAddress + size - 1;
+                    const nextAddress = editingCell + 1;
+
+                    if (nextAddress <= maxAddress && nextAddress <= 0xffff) {
+                        // Small delay to ensure the current edit is processed
+                        safeSetTimeout(() => {
+                            handleCellClick(nextAddress);
+                        }, 50);
+                    }
+                }
+            } else if (e.key === 'Escape') {
+                setEditingCell(null);
+                setEditValue('');
+            }
+        },
+        [editingCell, currentAddress, size, handleCellEditComplete, handleCellClick, safeSetTimeout],
+    );
+
+    const renderMemoryRow = useCallback(
+        (rowIndex: number) => {
+            const baseAddr = currentAddress + rowIndex * bytesPerRow;
+
+            return (
+                <MemoryRow
+                    key={baseAddr}
+                    baseAddr={baseAddr}
+                    bytesPerRow={bytesPerRow}
+                    memoryData={memoryData}
+                    editingCell={editingCell}
+                    editValue={editValue}
+                    workerManager={workerManager}
+                    maxAddress={0xffff}
+                    memoryMap={memoryMap}
+                    onCellClick={handleCellClick}
+                    onCellEdit={handleCellEdit}
+                    onCellEditComplete={handleCellEditComplete}
+                    onKeyDown={handleKeyDown}
+                />
+            );
+        },
+        [
+            currentAddress,
+            bytesPerRow,
+            memoryData,
+            editingCell,
+            editValue,
+            workerManager,
+            memoryMap,
+            handleCellClick,
+            handleCellEdit,
+            handleCellEditComplete,
+            handleKeyDown,
+        ],
+    );
 
     return (
-        <div ref={containerRef} className="h-full flex flex-col bg-surface-primary rounded-lg border border-border-primary">
+        <div
+            ref={containerRef}
+            className="h-full flex flex-col bg-surface-primary rounded-lg border border-border-primary"
+        >
             {/* Controls */}
             <div className="flex items-center gap-sm p-sm border-b border-border-subtle">
                 <label className="text-xs text-text-secondary">Address:</label>
@@ -451,7 +481,7 @@ const MemoryViewerPaginated: React.FC<MemoryViewerProps> = ({
                     value={addressInput}
                     onChange={handleAddressChange}
                     onKeyDown={handleAddressSubmit}
-                    className="w-20 px-2 py-1 text-xs font-mono bg-black/40 border border-border-primary rounded-sm text-data-address focus:border-border-accent focus:outline-hidden"
+                    className="w-20 px-2 py-1 text-xs font-mono bg-surface-sunken/40 border border-border-primary rounded-sm text-data-address focus:border-border-accent focus:outline-hidden"
                     placeholder="0000"
                 />
                 <div className="flex gap-xs">
@@ -471,19 +501,20 @@ const MemoryViewerPaginated: React.FC<MemoryViewerProps> = ({
                     </button>
                 </div>
                 <div className="flex-1 text-xs text-text-secondary text-center font-mono">
-                    ${Formatters.hex(currentAddress, 4)} - ${Formatters.hex(Math.min(0xFFFF, currentAddress + size - 1), 4)}
+                    ${Formatters.hex(currentAddress, 4)} - $
+                    {Formatters.hex(Math.min(0xffff, currentAddress + size - 1), 4)}
                 </div>
-                <div className="text-xs text-text-muted">
-                    ↑↓: Navigate • {effectiveRows} rows
-                </div>
+                <div className="text-xs text-text-muted">↑↓: Navigate • {effectiveRows} rows</div>
             </div>
 
             {/* Memory Table - No scroll, fixed height based on visible rows */}
-            <div ref={contentRef} className="flex-1 bg-black/20 overflow-hidden">
+            <div ref={contentRef} className="flex-1 bg-surface-sunken/20 overflow-hidden">
                 <table className="w-full">
                     <thead className="bg-surface-primary border-b border-border-primary">
                         <tr>
-                            <th className="px-2 py-1 text-left text-xs text-text-secondary font-normal whitespace-nowrap">Addr</th>
+                            <th className="px-2 py-1 text-left text-xs text-text-secondary font-normal whitespace-nowrap">
+                                Addr
+                            </th>
                             {Array.from({ length: bytesPerRow }, (_, i) => (
                                 <th key={i} className="px-2 py-1 text-center text-xs text-text-secondary font-normal">
                                     {Formatters.hex(i, 1)}
@@ -494,9 +525,7 @@ const MemoryViewerPaginated: React.FC<MemoryViewerProps> = ({
                             </th>
                         </tr>
                     </thead>
-                    <tbody>
-                        {Array.from({ length: effectiveRows }, (_, i) => renderMemoryRow(i))}
-                    </tbody>
+                    <tbody>{Array.from({ length: effectiveRows }, (_, i) => renderMemoryRow(i))}</tbody>
                 </table>
             </div>
         </div>

--- a/src/components/PaginatedTableView.tsx
+++ b/src/components/PaginatedTableView.tsx
@@ -5,29 +5,29 @@ interface PaginatedTableViewProps {
     // Basic configuration
     currentAddress: number;
     onAddressChange: (address: number) => void;
-    
+
     // Content rendering
     renderTableHeader: () => ReactNode;
     renderTableRows: () => ReactNode;
-    
+
     // Optional sections
     renderExtraControls?: () => ReactNode;
     renderStatusInfo?: () => ReactNode;
-    
+
     // Navigation
     onNavigateUp: () => void;
     onNavigateDown: () => void;
-    
+
     // Display info
     addressRange?: string;
     rowCount: number;
-    
+
     // Keyboard shortcuts help text
     keyboardShortcuts?: string;
-    
+
     // Styling
     className?: string;
-    
+
     // External refs (optional)
     containerRef?: React.RefObject<HTMLDivElement | null>;
     contentRef?: React.RefObject<HTMLDivElement | null>;
@@ -47,28 +47,26 @@ const PaginatedTableView: React.FC<PaginatedTableViewProps> = ({
     keyboardShortcuts = '↑↓: Navigate',
     className = '',
     containerRef: externalContainerRef,
-    contentRef: externalContentRef
+    contentRef: externalContentRef,
 }) => {
-    const [addressInput, setAddressInput] = useState(
-        Formatters.hex(currentAddress, 4)
-    );
+    const [addressInput, setAddressInput] = useState(Formatters.hex(currentAddress, 4));
     const internalContainerRef = useRef<HTMLDivElement>(null);
     const internalContentRef = useRef<HTMLDivElement>(null);
-    
+
     // Use external refs if provided, otherwise use internal ones
     const containerRef = externalContainerRef || internalContainerRef;
     const contentRef = externalContentRef || internalContentRef;
-    
+
     // Update address input when currentAddress changes
     useEffect(() => {
         setAddressInput(Formatters.hex(currentAddress, 4));
     }, [currentAddress]);
-    
+
     // Handle address input
     const handleAddressChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
         // Allow $ prefix and hex digits
         const value = e.target.value.toUpperCase();
-        
+
         // If it starts with $, keep it and ensure the rest is hex
         if (value.startsWith('$')) {
             const hexPart = value.slice(1).replace(/[^0-9A-F]/g, '');
@@ -83,26 +81,27 @@ const PaginatedTableView: React.FC<PaginatedTableViewProps> = ({
             }
         }
     }, []);
-    
-    const handleAddressSubmit = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === 'Enter') {
-            // Handle $ prefix for hex values
-            const cleanInput = addressInput.startsWith('$') 
-                ? addressInput.slice(1) 
-                : addressInput;
-            const addr = parseInt(cleanInput || '0', 16);
-            if (!isNaN(addr) && addr >= 0 && addr <= 0xFFFF) {
-                onAddressChange(addr);
+
+    const handleAddressSubmit = useCallback(
+        (e: React.KeyboardEvent<HTMLInputElement>) => {
+            if (e.key === 'Enter') {
+                // Handle $ prefix for hex values
+                const cleanInput = addressInput.startsWith('$') ? addressInput.slice(1) : addressInput;
+                const addr = parseInt(cleanInput || '0', 16);
+                if (!isNaN(addr) && addr >= 0 && addr <= 0xffff) {
+                    onAddressChange(addr);
+                }
             }
-        }
-    }, [addressInput, onAddressChange]);
-    
+        },
+        [addressInput, onAddressChange],
+    );
+
     // Keyboard navigation
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
             // Don't handle if input is focused
             if (document.activeElement?.tagName === 'INPUT') return;
-            
+
             if (e.key === 'ArrowUp') {
                 e.preventDefault();
                 onNavigateUp();
@@ -111,14 +110,14 @@ const PaginatedTableView: React.FC<PaginatedTableViewProps> = ({
                 onNavigateDown();
             }
         };
-        
+
         window.addEventListener('keydown', handleKeyDown);
         return () => window.removeEventListener('keydown', handleKeyDown);
     }, [onNavigateUp, onNavigateDown]);
-    
+
     return (
-        <div 
-            ref={containerRef} 
+        <div
+            ref={containerRef}
             className={`h-full flex flex-col bg-surface-primary rounded-lg border border-border-primary ${className}`}
         >
             {/* Controls Header */}
@@ -132,7 +131,7 @@ const PaginatedTableView: React.FC<PaginatedTableViewProps> = ({
                             value={addressInput}
                             onChange={handleAddressChange}
                             onKeyDown={handleAddressSubmit}
-                            className="bg-black/40 border border-border-primary text-data-address px-2 py-1 w-20 font-mono text-xs rounded-sm transition-colors focus:border-border-accent focus:outline-hidden"
+                            className="bg-surface-sunken/40 border border-border-primary text-data-address px-2 py-1 w-20 font-mono text-xs rounded-sm transition-colors focus:border-border-accent focus:outline-hidden"
                             placeholder="0000"
                             maxLength={4}
                         />
@@ -153,7 +152,7 @@ const PaginatedTableView: React.FC<PaginatedTableViewProps> = ({
                             </button>
                         </div>
                     </div>
-                    
+
                     {/* Optional separator and extra controls */}
                     {renderExtraControls && (
                         <>
@@ -161,36 +160,24 @@ const PaginatedTableView: React.FC<PaginatedTableViewProps> = ({
                             {renderExtraControls()}
                         </>
                     )}
-                    
+
                     {/* Status info on the right */}
                     <div className="flex items-center gap-xs ml-auto">
                         {renderStatusInfo && renderStatusInfo()}
-                        {addressRange && (
-                            <span className="text-xs text-text-secondary font-mono">
-                                {addressRange}
-                            </span>
-                        )}
-                        <span className="text-xs text-text-muted">
-                            {rowCount} rows
-                        </span>
+                        {addressRange && <span className="text-xs text-text-secondary font-mono">{addressRange}</span>}
+                        <span className="text-xs text-text-muted">{rowCount} rows</span>
                     </div>
                 </div>
-                
+
                 {/* Keyboard shortcuts help */}
-                {keyboardShortcuts && (
-                    <div className="mt-xs text-xs text-text-muted">
-                        {keyboardShortcuts}
-                    </div>
-                )}
+                {keyboardShortcuts && <div className="mt-xs text-xs text-text-muted">{keyboardShortcuts}</div>}
             </div>
-            
+
             {/* Table Content */}
-            <div ref={contentRef} className="flex-1 bg-black/20 overflow-hidden">
+            <div ref={contentRef} className="flex-1 bg-surface-sunken/20 overflow-hidden">
                 <table className="w-full">
                     {renderTableHeader()}
-                    <tbody>
-                        {renderTableRows()}
-                    </tbody>
+                    <tbody>{renderTableRows()}</tbody>
                 </table>
             </div>
         </div>

--- a/src/components/StackViewer.tsx
+++ b/src/components/StackViewer.tsx
@@ -13,9 +13,9 @@ interface StackMemoryData {
     [address: string]: number;
 }
 
-const StackViewer: React.FC<StackViewerProps> = ({ workerManager, stackPointer = 0xFF }) => {
+const StackViewer: React.FC<StackViewerProps> = ({ workerManager, stackPointer = 0xff }) => {
     const [stackData, setStackData] = useState<StackMemoryData>({});
-    
+
     // 6502 stack is at $0100-$01FF
     const STACK_BASE = 0x0100;
     const STACK_SIZE = 0x100;
@@ -46,16 +46,16 @@ const StackViewer: React.FC<StackViewerProps> = ({ workerManager, stackPointer =
     // Show only the active portion of the stack (from SP to FF)
     const renderStackEntries = () => {
         const entries = [];
-        
+
         // Stack grows downward, so we show from current SP up to FF
-        for (let offset = stackPointer; offset <= 0xFF; offset++) {
+        for (let offset = stackPointer; offset <= 0xff; offset++) {
             const addr = STACK_BASE + offset;
             const addrKey = Formatters.hexWord(addr);
             const value = stackData[addrKey] ?? 0;
             const isCurrent = offset === stackPointer;
-            
+
             entries.push(
-                <div 
+                <div
                     key={addr}
                     className={`flex justify-between items-center px-2 py-1 text-xs font-mono border-b border-border-subtle ${
                         isCurrent ? 'bg-info/20 border-info' : 'hover:bg-surface-hover/50'
@@ -73,28 +73,26 @@ const StackViewer: React.FC<StackViewerProps> = ({ workerManager, stackPointer =
                             className="text-xs"
                         />
                     </span>
-                    <span className="text-data-value">
-                        {Formatters.hex(value, 2)}
-                    </span>
-                </div>
+                    <span className="text-data-value">{Formatters.hex(value, 2)}</span>
+                </div>,
             );
         }
-        
+
         // If stack is empty (SP = FF), show a message
-        if (stackPointer === 0xFF) {
+        if (stackPointer === 0xff) {
             entries.push(
                 <div key="empty" className="text-center text-text-secondary text-xs py-2">
                     Stack is empty
-                </div>
+                </div>,
             );
         }
-        
+
         return entries;
     };
 
     // Calculate stack usage
-    const stackUsage = 0xFF - stackPointer;
-    const stackPercentage = (stackUsage / 0xFF) * 100;
+    const stackUsage = 0xff - stackPointer;
+    const stackPercentage = (stackUsage / 0xff) * 100;
 
     return (
         <div className="h-full flex flex-col" style={{ minHeight: 0 }}>
@@ -102,23 +100,17 @@ const StackViewer: React.FC<StackViewerProps> = ({ workerManager, stackPointer =
             <div className="mb-sm">
                 <div className="flex justify-between items-center mb-xs">
                     <span className="text-xs text-text-secondary">Stack Pointer:</span>
-                    <span className="text-xs font-mono text-data-value">
-                        {Formatters.hexByte(stackPointer)}
-                    </span>
+                    <span className="text-xs font-mono text-data-value">{Formatters.hexByte(stackPointer)}</span>
                 </div>
                 <div className="flex justify-between items-center mb-xs">
                     <span className="text-xs text-text-secondary">Usage:</span>
-                    <span className="text-xs font-mono">
-                        {stackUsage} / 255 bytes
-                    </span>
+                    <span className="text-xs font-mono">{stackUsage} / 255 bytes</span>
                 </div>
                 {/* Stack usage bar */}
                 <div className="w-full h-2 bg-surface-secondary rounded-full overflow-hidden">
-                    <div 
+                    <div
                         className={`h-full transition-all ${
-                            stackPercentage > 80 ? 'bg-error' : 
-                            stackPercentage > 60 ? 'bg-warning' : 
-                            'bg-success'
+                            stackPercentage > 80 ? 'bg-error' : stackPercentage > 60 ? 'bg-warning' : 'bg-success'
                         }`}
                         style={{ width: `${stackPercentage}%` }}
                     />
@@ -126,16 +118,14 @@ const StackViewer: React.FC<StackViewerProps> = ({ workerManager, stackPointer =
             </div>
 
             {/* Stack Contents */}
-            <div className="flex-1 overflow-auto bg-black/20 rounded-sm border border-border-subtle">
+            <div className="flex-1 overflow-auto bg-surface-sunken/20 rounded-sm border border-border-subtle">
                 <div className="sticky top-0 bg-surface-primary border-b border-border-primary px-2 py-1">
                     <div className="flex justify-between text-xs text-text-secondary">
                         <span>Address</span>
                         <span>Value</span>
                     </div>
                 </div>
-                <div>
-                    {renderStackEntries()}
-                </div>
+                <div>{renderStackEntries()}</div>
             </div>
 
             {/* Stack Operations Info */}

--- a/src/styles/__tests__/token-tailwind-parity.vitest.test.ts
+++ b/src/styles/__tests__/token-tailwind-parity.vitest.test.ts
@@ -77,4 +77,19 @@ describe('token ↔ Tailwind parity', () => {
         expect((tokenDerivedTheme.colors.component as Record<string, string>).cpu).toBe('#EF4444');
         expect((tokenDerivedTheme.colors.surface as Record<string, string>).primary).toBe('#1E293B');
     });
+
+    // v4-cleanup: tokens that repair previously-dead component classes
+    // (`bg-surface-hover`, `text-text-disabled`) and replace hardcoded translucent
+    // blacks (`bg-black/{40,20}` → `bg-surface-sunken/{40,20}`).
+    it('exposes the surface.hover / surface.sunken / text.disabled repair tokens', () => {
+        const surface = tokenDerivedTheme.colors.surface as Record<string, string>;
+        const text = tokenDerivedTheme.colors.text as Record<string, string>;
+        expect(surface.hover, 'surface.hover').toBe('#334155');
+        expect(surface.sunken, 'surface.sunken').toBe('#000000');
+        expect(text.disabled, 'text.disabled').toBe('#6B7280');
+        // and they must be wired into the resolved Tailwind theme, not just the adapter
+        expect((resolved.colors?.surface as Record<string, string>)?.hover).toBe('#334155');
+        expect((resolved.colors?.surface as Record<string, string>)?.sunken).toBe('#000000');
+        expect((resolved.colors?.text as Record<string, string>)?.disabled).toBe('#6B7280');
+    });
 });

--- a/src/styles/tailwind-tokens.ts
+++ b/src/styles/tailwind-tokens.ts
@@ -52,6 +52,8 @@ export const tokenDerivedTheme = {
             tertiary: colors.surface.tertiary,
             quaternary: colors.surface.quaternary,
             overlay: colors.surface.overlay,
+            hover: colors.surface.hover,
+            sunken: colors.surface.sunken,
         },
 
         // Border colors
@@ -69,6 +71,7 @@ export const tokenDerivedTheme = {
             tertiary: colors.text.tertiary,
             accent: colors.text.accent,
             muted: colors.text.muted,
+            disabled: colors.text.disabled,
         },
 
         // Component type colors — PascalCase token keys → lowercase Tailwind keys.

--- a/src/styles/tokens.ts
+++ b/src/styles/tokens.ts
@@ -97,6 +97,8 @@ export const designTokens = {
             tertiary: '#334155', // Lighter slate
             quaternary: '#475569', // Lightest slate
             overlay: '#00000060', // Black with 60% opacity
+            hover: '#334155', // Hover lift over primary (== tertiary; semantic alias)
+            sunken: '#000000', // Recessed panel; used translucent via opacity modifiers (bg-surface-sunken/40)
         },
 
         // Border colors
@@ -114,6 +116,7 @@ export const designTokens = {
             tertiary: '#6B7280', // Darker gray (same as muted)
             accent: '#10B981', // Green accent
             muted: '#6B7280', // Darker gray
+            disabled: '#6B7280', // Disabled/inactive text (== neutral.500; semantic alias)
         },
 
         // Component type colors for consistent mapping

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '4.51.1';
+export const APP_VERSION = '4.51.2';

--- a/yarn.lock
+++ b/yarn.lock
@@ -204,11 +204,6 @@
   dependencies:
     css-tree "^3.0.0"
 
-"@colordx/core@^5.4.3":
-  version "5.4.3"
-  resolved "https://registry.yarnpkg.com/@colordx/core/-/core-5.4.3.tgz#35a8d239b324a6cdf9a16de9970a32c8abc24824"
-  integrity sha512-kIxYSfA5T8HXjav55UaaH/o/cKivF6jCCGIb8eqtcsfI46wsvlSiT8jMDyrl779qLec3c2c2oHBZo4oAhvbjrQ==
-
 "@commitlint/cli@^21.0.1":
   version "21.0.2"
   resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-21.0.2.tgz#34f006f2ffa77ade13a6bfe97296290f99aaddeb"
@@ -1390,11 +1385,6 @@ bidi-js@^1.0.3:
   dependencies:
     require-from-string "^2.0.2"
 
-boolbase@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
-  integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
-
 brace-expansion@^1.1.7:
   version "1.1.14"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.14.tgz#d9de602370d91347cd9ddad1224d4fd701eb348b"
@@ -1417,7 +1407,7 @@ braces@^3.0.3:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.0.0, browserslist@^4.24.0, browserslist@^4.28.1, browserslist@^4.28.2:
+browserslist@^4.24.0:
   version "4.28.2"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.2.tgz#f50b65362ef48974ca9f50b3680566d786b811d2"
   integrity sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==
@@ -1464,17 +1454,7 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
-caniuse-api@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-3.0.0.tgz#5e4d90e2274961d46291997df599e3ed008ee4c0"
-  integrity sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==
-  dependencies:
-    browserslist "^4.0.0"
-    caniuse-lite "^1.0.0"
-    lodash.memoize "^4.1.2"
-    lodash.uniq "^4.5.0"
-
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001782:
+caniuse-lite@^1.0.30001782:
   version "1.0.30001793"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz#238887ddf5fcfc8c36d872394d0a78a517312a72"
   integrity sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==
@@ -1553,11 +1533,6 @@ comlink@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/comlink/-/comlink-4.4.2.tgz#cbbcd82742fbebc06489c28a183eedc5c60a2bca"
   integrity sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==
-
-commander@^11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-11.1.0.tgz#62fdce76006a68e5c1ab3314dc92e800eb83d906"
-  integrity sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==
 
 commander@^2.20.0:
   version "2.20.3"
@@ -1646,18 +1621,7 @@ cross-spawn@^7.0.6:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-css-select@^5.1.0:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.2.2.tgz#01b6e8d163637bb2dd6c982ca4ed65863682786e"
-  integrity sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==
-  dependencies:
-    boolbase "^1.0.0"
-    css-what "^6.1.0"
-    domhandler "^5.0.2"
-    domutils "^3.0.1"
-    nth-check "^2.0.1"
-
-css-tree@^3.0.0, css-tree@^3.0.1, css-tree@^3.2.1:
+css-tree@^3.0.0, css-tree@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-3.2.1.tgz#86cac7011561272b30e6b1e042ba6ce047aa7518"
   integrity sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==
@@ -1665,83 +1629,10 @@ css-tree@^3.0.0, css-tree@^3.0.1, css-tree@^3.2.1:
     mdn-data "2.27.1"
     source-map-js "^1.2.1"
 
-css-tree@~2.2.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-2.2.1.tgz#36115d382d60afd271e377f9c5f67d02bd48c032"
-  integrity sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==
-  dependencies:
-    mdn-data "2.0.28"
-    source-map-js "^1.0.1"
-
-css-what@^6.1.0:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.2.2.tgz#cdcc8f9b6977719fdfbd1de7aec24abf756b9dea"
-  integrity sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==
-
 css.escape@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
   integrity sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==
-
-cssesc@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
-  integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
-
-cssnano-preset-default@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/cssnano-preset-default/-/cssnano-preset-default-8.0.1.tgz#7f8fca224b0e7e8dce6d4fa6d362e02a2c7d4ecf"
-  integrity sha512-OTdKeYMlvQ8KBgyej5ysktnWJoeyo7rGrVnm+bdpIHGvxhbTGPsOkB+7T1EdTuX00dGlQQb2UEbSPB1OpMXULw==
-  dependencies:
-    browserslist "^4.28.2"
-    cssnano-utils "^6.0.0"
-    postcss-calc "^10.1.1"
-    postcss-colormin "^8.0.0"
-    postcss-convert-values "^8.0.0"
-    postcss-discard-comments "^8.0.0"
-    postcss-discard-duplicates "^8.0.0"
-    postcss-discard-empty "^8.0.0"
-    postcss-discard-overridden "^8.0.0"
-    postcss-merge-longhand "^8.0.0"
-    postcss-merge-rules "^8.0.0"
-    postcss-minify-font-values "^8.0.0"
-    postcss-minify-gradients "^8.0.0"
-    postcss-minify-params "^8.0.0"
-    postcss-minify-selectors "^8.0.1"
-    postcss-normalize-charset "^8.0.0"
-    postcss-normalize-display-values "^8.0.0"
-    postcss-normalize-positions "^8.0.0"
-    postcss-normalize-repeat-style "^8.0.0"
-    postcss-normalize-string "^8.0.0"
-    postcss-normalize-timing-functions "^8.0.0"
-    postcss-normalize-unicode "^8.0.0"
-    postcss-normalize-url "^8.0.0"
-    postcss-normalize-whitespace "^8.0.0"
-    postcss-ordered-values "^8.0.0"
-    postcss-reduce-initial "^8.0.0"
-    postcss-reduce-transforms "^8.0.0"
-    postcss-svgo "^8.0.0"
-    postcss-unique-selectors "^8.0.0"
-
-cssnano-utils@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/cssnano-utils/-/cssnano-utils-6.0.0.tgz#0575409ebe63cd0b483e17e6aeaafd540e865161"
-  integrity sha512-ztS9W/+uaDn+bkYmDhs+GdMveHJ3CL8IPNHpRqDUQXv5GJOTQAJjV1XUOInr9esLXSabQV1pLRZlJpyUwEqDyQ==
-
-cssnano@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-8.0.1.tgz#0f86d0ed9210bc9de824751eb2ab6b0c909b03d7"
-  integrity sha512-oSiOnPQNNYjusTUlYJiE6xvFQG4don3N0QavaoV1BxIsC1zjvxOwikXlR7lG1EVmZNDDaJkHbQx1VRB8kaoMHA==
-  dependencies:
-    cssnano-preset-default "^8.0.1"
-    lilconfig "^3.1.3"
-
-csso@^5.0.5:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/csso/-/csso-5.0.5.tgz#f9b7fe6cc6ac0b7d90781bb16d5e9874303e2ca6"
-  integrity sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==
-  dependencies:
-    css-tree "~2.2.0"
 
 csstype@^3.2.2:
   version "3.2.3"
@@ -1859,36 +1750,6 @@ dom-accessibility-api@^0.6.3:
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz#993e925cc1d73f2c662e7d75dd5a5445259a8fd8"
   integrity sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==
 
-dom-serializer@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
-  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
-  dependencies:
-    domelementtype "^2.3.0"
-    domhandler "^5.0.2"
-    entities "^4.2.0"
-
-domelementtype@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
-  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
-
-domhandler@^5.0.2, domhandler@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
-  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
-  dependencies:
-    domelementtype "^2.3.0"
-
-domutils@^3.0.1:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.2.2.tgz#edbfe2b668b0c1d97c24baf0f1062b132221bc78"
-  integrity sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==
-  dependencies:
-    dom-serializer "^2.0.0"
-    domelementtype "^2.3.0"
-    domhandler "^5.0.3"
-
 dot-prop@^5.1.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.3.0.tgz#90ccce708cd9cd82cc4dc8c3ddd9abdd55b20e88"
@@ -1923,7 +1784,7 @@ enhanced-resolve@^5.21.0:
     graceful-fs "^4.2.4"
     tapable "^2.3.3"
 
-entities@^4.2.0, entities@^4.4.0:
+entities@^4.4.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
@@ -3091,11 +2952,6 @@ lightningcss@1.32.0, lightningcss@^1.32.0:
     lightningcss-win32-arm64-msvc "1.32.0"
     lightningcss-win32-x64-msvc "1.32.0"
 
-lilconfig@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-3.1.3.tgz#a1bcfd6257f9585bf5ae14ceeebb7b559025e4c4"
-  integrity sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==
-
 lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
@@ -3125,20 +2981,10 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash.memoize@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
-  integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
-
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
-
-lodash.uniq@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
-  integrity sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==
 
 loose-envify@^1.4.0:
   version "1.4.0"
@@ -3222,11 +3068,6 @@ math-intrinsics@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
-
-mdn-data@2.0.28:
-  version "2.0.28"
-  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.28.tgz#5ec48e7bef120654539069e1ae4ddc81ca490eba"
-  integrity sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==
 
 mdn-data@2.27.1:
   version "2.27.1"
@@ -3590,13 +3431,6 @@ npm-run-all@^4.1.5:
     shell-quote "^1.6.1"
     string.prototype.padend "^3.0.0"
 
-nth-check@^2.0.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
-  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
-  dependencies:
-    boolbase "^1.0.0"
-
 object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
@@ -3800,220 +3634,6 @@ possible-typed-array-names@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz#93e3582bc0e5426586d9d07b79ee40fc841de4ae"
   integrity sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==
-
-postcss-calc@^10.1.1:
-  version "10.1.1"
-  resolved "https://registry.yarnpkg.com/postcss-calc/-/postcss-calc-10.1.1.tgz#52b385f2e628239686eb6e3a16207a43f36064ca"
-  integrity sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw==
-  dependencies:
-    postcss-selector-parser "^7.0.0"
-    postcss-value-parser "^4.2.0"
-
-postcss-colormin@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-colormin/-/postcss-colormin-8.0.0.tgz#1f484022fbc2b2a135e158d4af0578313eb35a76"
-  integrity sha512-KKwMmsSgsmdYXqrjQeqL3tnuIFtctiR1GEMHdjNpDpz/TCRkkkok2mMcreK2zVV3l7POWOmAkR2xYHUpRUK1DA==
-  dependencies:
-    "@colordx/core" "^5.4.3"
-    browserslist "^4.28.2"
-    caniuse-api "^3.0.0"
-    postcss-value-parser "^4.2.0"
-
-postcss-convert-values@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-convert-values/-/postcss-convert-values-8.0.0.tgz#c279c973fbb24bc6ec63cc64b67b557fbfbedd12"
-  integrity sha512-Ohtj3rNZWawTRePv5NCHTy8VJSdJ/G/uKuxcxJreOMichuqcT6uEl2TAnopVeJCJ/c13jaSqg7m63yFLM5zBsA==
-  dependencies:
-    browserslist "^4.28.2"
-    postcss-value-parser "^4.2.0"
-
-postcss-discard-comments@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-discard-comments/-/postcss-discard-comments-8.0.0.tgz#d10864ec1d2cd34a61e66a07dc6373a2a62b9908"
-  integrity sha512-zGpvVLj2sbagEp+BTVETvAfkZdGVA6rALNujDK/WTIjdf1/rQOxOG8BBzkI8UQgnw8SkL6xffAfbtGMHFypadw==
-  dependencies:
-    postcss-selector-parser "^7.1.1"
-
-postcss-discard-duplicates@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-discard-duplicates/-/postcss-discard-duplicates-8.0.0.tgz#cbef4a8e910c015d86bbfc745c25a000724b5da6"
-  integrity sha512-zjRyYmNGI3PTipKBBtCgExlmZXQn49KvKoaiNnR2g+iXxeNk7GY5Js2ULtZXPrCYeqjPagrzKIBNcBocvXCR7g==
-
-postcss-discard-empty@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-discard-empty/-/postcss-discard-empty-8.0.0.tgz#de228cf50b29273f18305bbce9cc4e44050d646a"
-  integrity sha512-kxPJg6EqahbBvm+l7hpYYCtpsv8dlz7Tv6wJXUXZaeuY0WGS61DxfGdZR4uVB/Cx+yi3iOHQVSqpSHKMFaBg6Q==
-
-postcss-discard-overridden@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-discard-overridden/-/postcss-discard-overridden-8.0.0.tgz#c43f8c10d65b77315ead38b0e8da054045856e6f"
-  integrity sha512-sW2OWH3l9p0FmBSVr228uztFseqroZxwgD7SGF0Ks0dRPDttSo3P8FK5ZBLtWBH2A5+chpB0J2fB/T8heKHLBw==
-
-postcss-merge-longhand@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-merge-longhand/-/postcss-merge-longhand-8.0.0.tgz#d6a4028edcf2115f03e90f4638e3d10f49abc45c"
-  integrity sha512-YDmAmQ8H+ljfomVpSXvr9NA0GP01fraQJqjWBYoMVGg6rOT+PJLwPyeVo2ekn4WB4ZVSH5ddtK3DTRxbz6CFzg==
-  dependencies:
-    postcss-value-parser "^4.2.0"
-    stylehacks "^8.0.0"
-
-postcss-merge-rules@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-merge-rules/-/postcss-merge-rules-8.0.0.tgz#4ed85545a3f6f82a72d20d1c5d1afcc07bb1071e"
-  integrity sha512-bgstL5mpi41dDpnYGDUcI3M814NWkCMcIWpwDqEHXkHg3BT7b4XRAfNEuwJncZOVn/67kVKvWzhfv/7xyrp2uQ==
-  dependencies:
-    browserslist "^4.28.2"
-    caniuse-api "^3.0.0"
-    cssnano-utils "^6.0.0"
-    postcss-selector-parser "^7.1.1"
-
-postcss-minify-font-values@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-minify-font-values/-/postcss-minify-font-values-8.0.0.tgz#05a6d78c6a56927d1f543e946b6cce25b7555a17"
-  integrity sha512-EnOHQEnSt6oH5NrL1DMFAQuwB2IOimFXTCzc9bKfUeH1jREbqIF5MAK4gQJQOC4mPUwJt4sWifAmNZ1qLu6j3Q==
-  dependencies:
-    postcss-value-parser "^4.2.0"
-
-postcss-minify-gradients@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-minify-gradients/-/postcss-minify-gradients-8.0.0.tgz#1c452320d04fb92879f82e81327ad69c03e797f8"
-  integrity sha512-43iAnYIGk0ZjNx5X/rkIcHi6dhmu/vEjY0kqfUfxPuJRO+V7jx8uKIdcnL0dpfNoC5J9TSh3EtzLWbq0gpqnWA==
-  dependencies:
-    "@colordx/core" "^5.4.3"
-    cssnano-utils "^6.0.0"
-    postcss-value-parser "^4.2.0"
-
-postcss-minify-params@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-minify-params/-/postcss-minify-params-8.0.0.tgz#b92cad82af1dd9262a8dc85405cb3788563ec1c7"
-  integrity sha512-z7w4QO7G55l4vMUK1Lmx03GW7iyRLgf2V5Dz/7ioSPLnXRjeD+b7m0XfAXUGrbBYYrJ6bXPk+3LoX5u4JfAcSg==
-  dependencies:
-    browserslist "^4.28.2"
-    cssnano-utils "^6.0.0"
-    postcss-value-parser "^4.2.0"
-
-postcss-minify-selectors@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-minify-selectors/-/postcss-minify-selectors-8.0.1.tgz#7a64f8b5e2fc8a69968828d96e46b4d1e8cdf417"
-  integrity sha512-c31D46811kTkQDxV1KTTow79axX6gj/01AY5G7cGZg3s31KvAwP13jEFXGAzQbJ7NvOFV1pRqEia6nrAdHU7qg==
-  dependencies:
-    browserslist "^4.28.1"
-    caniuse-api "^3.0.0"
-    cssesc "^3.0.0"
-    postcss-selector-parser "^7.1.1"
-
-postcss-normalize-charset@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-charset/-/postcss-normalize-charset-8.0.0.tgz#6ebed303bd5ea21cb74991ba436fd21047e54881"
-  integrity sha512-s88FUNDSUD8m0wBYvTQQcubVts6zhXwBU8zCD4vkRKiecd0v8cOjHVIF9r/i+5xzS/WG3f98qq4XsOM0JqvfLA==
-
-postcss-normalize-display-values@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-display-values/-/postcss-normalize-display-values-8.0.0.tgz#c37d17382a19ecd30b69c1b2a3b8cef3fc46a907"
-  integrity sha512-gG2nBxD27fiw6Luinb1QYKdM/Co5GornRJgSD+JTwNH4PGKxImP0qyruDDav49aHUPLY3qrL3qN3LvybO7IzxQ==
-  dependencies:
-    postcss-value-parser "^4.2.0"
-
-postcss-normalize-positions@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-positions/-/postcss-normalize-positions-8.0.0.tgz#2fec52bdd6586890a0e337019525525ce4d43c52"
-  integrity sha512-t/wGqpehS20Ke7kc4QAsWpH+AJjUdMK/V5qV2RhrXkj8hO/fT1t1MJ8NL7sedWYk7ZqC7eISEJQonW5j0tU1MQ==
-  dependencies:
-    postcss-value-parser "^4.2.0"
-
-postcss-normalize-repeat-style@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-8.0.0.tgz#714e6dc7f493227dacca58cd04dfa8ff05ac38d4"
-  integrity sha512-3ebOmGdCYKrBYyGKc1xhj0unEnW7beZpVU7JohVeGl7mTxR+7T6egpaawTWAVsB0pEIhcsbJVOjPKCJSoRO6Zg==
-  dependencies:
-    postcss-value-parser "^4.2.0"
-
-postcss-normalize-string@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-string/-/postcss-normalize-string-8.0.0.tgz#b2c7a17e7a9910f52ac674c084f6058fae8d4a32"
-  integrity sha512-TvWCGZ/e04Tv31uJvOUtbexkfgUnqmQ3M2P5DkAaVzvOj+BvTkG2QjpA5Y71SL1SPxJcj4M23fNh+RDVCmG8kA==
-  dependencies:
-    postcss-value-parser "^4.2.0"
-
-postcss-normalize-timing-functions@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-8.0.0.tgz#414e9507cd8d8829053f34025a1b4972a38f01f8"
-  integrity sha512-uEfaXst5Xgqxv7geYUuz6vs9mn88K2NPY2RoIzM3BMmSjsdTSeppV9x2qIgrxsisdbSqF6IVhzI2occcte3hTA==
-  dependencies:
-    postcss-value-parser "^4.2.0"
-
-postcss-normalize-unicode@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-unicode/-/postcss-normalize-unicode-8.0.0.tgz#ef98281b18ddf94d1cbe99f8f3b03a45b107772d"
-  integrity sha512-+WYngZaChEeTHZmWhmKtnJ4gTzWdINEaFcgWBnu6WdVu8Ftim8OBTcw768DuCC/3Aax9bZ9WkwrLGHym2Lzf+A==
-  dependencies:
-    browserslist "^4.28.2"
-    postcss-value-parser "^4.2.0"
-
-postcss-normalize-url@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-url/-/postcss-normalize-url-8.0.0.tgz#b06d98916c0904fe4eb2d666381176f849363c59"
-  integrity sha512-4Mz9hZHn/QIB+YtFqTXrDmE2193GYxGb3F8uMfLvMicaEXCCUlDIJ658gFFJbqEGl9FYzwPtRiuNgbwlO9kkBg==
-  dependencies:
-    postcss-value-parser "^4.2.0"
-
-postcss-normalize-whitespace@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-whitespace/-/postcss-normalize-whitespace-8.0.0.tgz#49cddce4bbf2be7645114138fd7f9155fa19b7b1"
-  integrity sha512-V1f8tYnwIP5tscOXQFTKK8Y5EJ+R2GMpFJ6FjzwoKoQnhbqQy3IeSrDjJJb8JjVos8ut6Osi80Zybpayv/XjIQ==
-  dependencies:
-    postcss-value-parser "^4.2.0"
-
-postcss-ordered-values@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-ordered-values/-/postcss-ordered-values-8.0.0.tgz#391594f16279d473ef8155edbacf18b74ecc9a31"
-  integrity sha512-Dg9+itb6lmD0bxqhQyHCtXAwYRh0wUrx6Mp4/BNXgkLoJmdYMmWi+V+Pypw79Q6iQhxA8KFMHqLBITQJV2gKMA==
-  dependencies:
-    cssnano-utils "^6.0.0"
-    postcss-value-parser "^4.2.0"
-
-postcss-reduce-initial@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-reduce-initial/-/postcss-reduce-initial-8.0.0.tgz#30dd4a2ddb282bd5158b3efa80deb4dce1ed215a"
-  integrity sha512-DChcE9d528AKrlpCTHjhsAiOsWCk4H9ApHPS1QqRT3praObWTiWyn6W1UddGpc46K9LQnHwUu4YwaPUukGtXVA==
-  dependencies:
-    browserslist "^4.28.2"
-    caniuse-api "^3.0.0"
-
-postcss-reduce-transforms@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-reduce-transforms/-/postcss-reduce-transforms-8.0.0.tgz#ac1bdb975b8d6286b5e777ae207f2dd7b3f2812d"
-  integrity sha512-cLZT0som7vvumQT9XQCnSKOSnRinNQZd1Hm+J723Ney13E8CIydDhw6JwzsjPtgnYThTqn9Q45906gz6wxaAsw==
-  dependencies:
-    postcss-value-parser "^4.2.0"
-
-postcss-selector-parser@^7.0.0, postcss-selector-parser@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz#e75d2e0d843f620e5df69076166f4e16f891cb9f"
-  integrity sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==
-  dependencies:
-    cssesc "^3.0.0"
-    util-deprecate "^1.0.2"
-
-postcss-svgo@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-svgo/-/postcss-svgo-8.0.0.tgz#73b03a59ca001e8e3ab30e7deb622e511beb28eb"
-  integrity sha512-Q2fMSYEiNE1ioDc/3sxvI24NdgA/MJno2XLNpOxgv8aCcJbym8mZY10/lDY5+AWCIc3Aiqzy2Wcp9/zaIXBZgQ==
-  dependencies:
-    postcss-value-parser "^4.2.0"
-    svgo "^4.0.1"
-
-postcss-unique-selectors@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-unique-selectors/-/postcss-unique-selectors-8.0.0.tgz#bca788bebb5472b91cbca09d55ef35038a7e30bb"
-  integrity sha512-iObuolUX+ITJfMU2QQFQdh31JgSjNLPNjVs6YGAqBHvOvAWXMMNget6donQl83aQaeS32i5XeKZURUW/WBxIUw==
-  dependencies:
-    postcss-selector-parser "^7.1.1"
-
-postcss-value-parser@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
-  integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
 postcss@^8.5.10, postcss@^8.5.15, postcss@^8.5.6:
   version "8.5.15"
@@ -4240,11 +3860,6 @@ safe-regex-test@^1.1.0:
     es-errors "^1.3.0"
     is-regex "^1.2.1"
 
-sax@^1.5.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.6.0.tgz#da59637629307b97e7c4cb28e080a7bc38560d5b"
-  integrity sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==
-
 saxes@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/saxes/-/saxes-6.0.0.tgz#fe5b4a4768df4f14a201b1ba6a65c1f3d9988cc5"
@@ -4396,7 +4011,7 @@ smol-toml@1.6.1:
   resolved "https://registry.yarnpkg.com/smol-toml/-/smol-toml-1.6.1.tgz#4fceb5f7c4b86c2544024ef686e12ff0983465be"
   integrity sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==
 
-source-map-js@^1.0.1, source-map-js@^1.2.1:
+source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
@@ -4568,14 +4183,6 @@ strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-stylehacks@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-8.0.0.tgz#5676224ad2c83739de2170c2fd061d16e1b844eb"
-  integrity sha512-sWyjaJvBqHoVKYPbQ8JRvrGSPaYWtWrJsU+fGVtwKB1GE1rRPu3rC7T6UCuXLoL00Dwb+tsHe2T904r8Vnsx8w==
-  dependencies:
-    browserslist "^4.28.2"
-    postcss-selector-parser "^7.1.1"
-
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -4594,19 +4201,6 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
-
-svgo@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/svgo/-/svgo-4.0.1.tgz#c82dacd04ee9f1d55cd4e0b7f9a214c86670e3ee"
-  integrity sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==
-  dependencies:
-    commander "^11.1.0"
-    css-select "^5.1.0"
-    css-tree "^3.0.1"
-    css-what "^6.1.0"
-    csso "^5.0.5"
-    picocolors "^1.1.1"
-    sax "^1.5.0"
 
 symbol-tree@^3.2.4:
   version "3.2.4"
@@ -4817,11 +4411,6 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
-
-util-deprecate@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"


### PR DESCRIPTION
Follow-up to the Tailwind v3→v4 upgrade (#179), executing the two tech-debt items parked in `DECISIONS.md` D-006 plus a latent bug surfaced while scoping them. Logged as **D-007**.

## What changed

1. **Drop `cssnano`** — redundant under v4: `@tailwindcss/postcss` + Vite already minify CSS in production (verified the emitted `dist` CSS is minified without it). One dep + one config line gone.
2. **Repair two dead tokens** — components referenced `bg-surface-hover` (7×) and `text-text-disabled` (11×), but neither token existed in `tokens.ts`/the adapter, so those classes emitted **no CSS** (missing hover lift on rows/buttons, uncolored disabled flags/buttons). Added `surface.hover` (#334155) and `text.disabled` (#6B7280) — fixes all ~18 call sites with **zero component edits**.
3. **Tokenize hardcoded colors** — `bg-black/{40,20}` → `bg-surface-sunken/{40,20}` (new `surface.sunken` #000000; identical CSS via opacity modifier) across Info, PaginatedTableView, StackViewer, MemoryViewerPaginated (10 sites); unmapped-cell `text-gray-500!` → `text-text-tertiary!`.

**Out of scope (deferred):** error reds (`Error.tsx`/`AppContent`), `text-black` contrast text, `index.css` base defaults. **CRT colors exempt** (CLAUDE.md).

## Why the broken tokens slipped through

The token-parity test only guards **adapter → config** (forward: "every token is in the theme"), never **component → token** (reverse: "every class resolves"). So dead class references were invisible to CI.

## Verification

- `yarn test:ci` green — **759 passed, 20 skipped** (the skipped are browser-only WASM parity/benchmark tests). Parity test extended to lock the 3 new hex values.
- **`dist` CSS grep** (the deterministic RENDER check — Tailwind v4 only emits a utility when the class is *used* AND maps to a *real* token):
  - `bg-surface-hover{background-color:#334155}` — now emits (was absent)
  - `text-text-disabled,.text-text-muted{color:#6b7280}` — now emits (was absent)
  - `bg-surface-sunken/40` → `oklab(0% none none/.4)` — byte-identical to old `bg-black/40`
- Production build succeeds; `dist` CSS still minified.

Version bumped 4.51.1 → 4.51.2 (chore = patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing semantic color tokens causing incomplete CSS generation.
  * Enhanced memory viewer with keyboard shortcuts (Tab, Enter, Escape) for better editing.
  * Updated component styling consistency with new color system.

* **Tests**
  * Added validation for color token and theme compatibility.

* **Chores**
  * Removed CSS optimization dependency.
  * Version bumped to 4.51.2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stid/Apple1JS/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->