### PR TITLE
docs: promote durable best-practices into CLAUDE.md + test guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,11 @@
 4. **Keep the JS engine as fallback**; document performance differences.
 5. **No `any` types** (strict mode), **no `console.log`** (use LoggingService),
    **no hardcoded colors** (design tokens — except the CRT display).
-6. **Bump `src/version.ts`** before every PR — it's the single source of truth
-   for the app version (patch/minor/major per branch prefix).
+6. **Bump `src/version.ts`** before every PR — single source of truth for the app
+   version. Branch-prefix → bump: `feat/` = **minor**; `fix/` `refactor/` `chore/`
+   `docs/` `test/` = **patch**; **major** needs explicit approval. (A `refactor/` may
+   take a minor for a notable user-facing change — an owner override; resolve the
+   review thread rather than concede.)
 
 ## Quick Start Checklist
 
@@ -21,7 +24,7 @@
 git branch --show-current                         # 1. NEVER work on master
 git checkout -b <type>/<description>              # 2. branch if needed
 yarn test:ci                                      # 3. verify starting state
-cat src/version.ts                                # 4. check version (4.42.7)
+cat src/version.ts                                # 4. check current version
 yarn wasm:build:release                           # 5. build WASM (release = speed-first)
 # 6. Use the task tools for any multi-step work.
 ```
@@ -122,12 +125,22 @@ yarn test:coverage # coverage
 
 Test guidelines: `docs/active/cpu_test_guidelines.md`.
 
+**WASM core tests need a real browser.** Don't add native Rust tests on the CPU/`WasmSystem`
+path — `CPU6502::new()` / `WasmSystem::initialize()` call wasm-bindgen imports that panic under
+native `cargo test` (`yarn wasm:test` only runs the pure `bus.rs`/`ram.rs`/`rom.rs` component
+tests). The Node-vitest engine-parity suites load the wasm-pack "web" build via `fetch()` (absent
+in Node), so they `skipIf`/**skip in CI**. A Rust core change therefore gets `cargo check` + a
+skipped parity test — verify actual WASM behavior in a browser (see the test guidelines).
+
 ## Before ANY Commit
 
 ```bash
 yarn run lint && yarn run type-check && yarn run test:ci
-yarn run lint:md:fix    # after editing/creating any markdown
-# bump src/version.ts (patch/minor/major)
+npx markdownlint-cli2 --fix "<file.md>"   # ONLY the file(s) you edited
+# ⚠️ NEVER run the repo-wide `yarn lint:md:fix`: it corrupts the machine block in
+#    .claude/rules/lcd-conventions.md and reflows nested lists (prettier wants 4-space,
+#    markdownlint MD007 wants 2-space). md-lint is NOT in CI, so the breakage is silent.
+# bump src/version.ts — see the branch-prefix mapping in Critical Development Rules #6
 git add -A && git commit -m "type: description"   # feat:, fix:, docs:, ...
 git push
 ```
@@ -155,6 +168,14 @@ git push
 For UI changes, iterate against visuals: ask for current-state screenshots /
 mockups and concrete success criteria up front, then screenshot progress and
 iterate 2–3 times.
+
+**Verifying in a real browser:** the emulator runs a continuous worker/rAF loop, so the page
+never reaches `document_idle` — idle-gated screenshot / page-text tooling times out (don't retry
+it). Drive and inspect the DOM via in-page JS instead. For auto-dismissing UI (toasts clear after
+`UI_TIMINGS.TOAST_DURATION` ≈ 4s), sample within a **single** in-page async loop rather than across
+separate tool round-trips — the round-trip latency can miss the transient state and look like a
+bug. Dev server: `yarn dev` (builds the WASM release, then Vite on :3000); `yarn dev:vite` reuses
+prebuilt WASM for CSS/markup-only changes.
 
 ## GitHub CLI
 

--- a/docs/active/cpu_test_guidelines.md
+++ b/docs/active/cpu_test_guidelines.md
@@ -80,4 +80,21 @@ test('OPCODE ($HEX) - Description', function () {
 4. Reset vector points to correct address (0xff00)
 5. setupProgram is called in each test
 
+### 🧬 WASM core: where tests can and can't run
+
+The Rust/WASM 6502 core cannot be exercised by `cargo test` or Node vitest:
+
+- **Native `cargo test`** (`yarn wasm:test`): `CPU6502::new()` / `WasmSystem::initialize()`
+  call wasm-bindgen imports (`console_log!`, …) that panic on non-wasm targets. Only the pure
+  component tests (`bus.rs`, `ram.rs`, `rom.rs`) run natively — the `system.rs` / CPU-execution
+  tests fail on `master` too. **Don't add native Rust tests on the CPU/`WasmSystem` path; they
+  cannot pass.**
+- **Node vitest**: the wasm-pack "web" build loads via `fetch()`, absent in Node, so the
+  engine-parity suites are `describe.skipIf(!wasmRuntimeAvailable)` and **skip in CI**.
+
+So a Rust core change gets `cargo check` (compile) + a skipped parity test in CI — nothing
+exercises actual execution. **Verify WASM behavior in a real browser**: import the engine modules
+through Vite (e.g. `await import('/src/core/cpu-engines/WasmEngine.ts')`) so the real wasm-pack
+build runs, then build JS + WASM engines over a shared Bus and assert parity directly.
+
 ---

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '4.51.2';
+export const APP_VERSION = '4.51.3';


### PR DESCRIPTION
Promotes shareable project facts that lived only in machine-local Claude memory into the committed dev instructions, so they survive for any contributor / fresh clone. (Memory stays local for personal/sensitive notes; this is the "would it be true on someone else's machine?" subset.)

## Changes

- **Fixes a harmful instruction.** `CLAUDE.md` → "Before ANY Commit" told everyone to run repo-wide `yarn lint:md:fix`. That command **corrupts the machine block** in `.claude/rules/lcd-conventions.md` and reflows nested lists (prettier wants 4-space, markdownlint MD007 wants 2-space) — and md-lint isn't in CI, so the damage is silent. Now scopes `markdownlint-cli2 --fix` to the edited file with a `⚠️ never repo-wide` warning.
- **Explicit version-bump mapping** in Critical Development Rules #6: `feat/`=minor; `fix/ refactor/ chore/ docs/ test/`=patch; major needs approval; owner may override `refactor/`→minor for a notable UX change.
- **"WASM core tests need a real browser"** caveat in Testing Strategy + a fuller `🧬` section in `cpu_test_guidelines.md`: native `cargo test` panics on the CPU/`WasmSystem` path; Node-vitest parity suites skip in CI; verify via a Vite engine-module import in a browser.
- **Browser-verify reality** in "UI Work": the emulator's continuous loop means the page never hits `document_idle` (idle-gated tooling times out) → drive via in-page JS; sample auto-dismissing toasts within one in-page loop.
- **De-hardcode** the stale `(4.42.7)` in the Quick Start checklist.

## Verification

- `markdownlint-cli2 CLAUDE.md docs/active/cpu_test_guidelines.md` → **0 errors** (scoped, never repo-wide — practicing the rule being added).
- Edits made via Bash reconstruction (not the Edit tool) so the post-edit hook couldn't churn untouched lines; `git diff` is exactly the intended regions.
- `yarn test:ci` green (758 passed / 20 skipped — docs-only change).

Version 4.51.3, pinned above in-flight PR #181's 4.51.2 so the `src/version.ts` conflict resolves unambiguously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded development and testing guidance: clearer quick-start checks, guidance for verifying WASM behavior in a real browser, and notes on which tests can run natively vs. only in browser environments; improved instructions for reliable UI inspection and transient-state checks.
  * Updated markdown linting workflow guidance to avoid repo-wide corruption risks.
* **Chores**
  * Application version updated to 4.51.3

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stid/Apple1JS/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->