### PR TITLE
refactor: redesign CPU State + Execution debugger cards

### DIFF
--- a/src/components/CpuStateCard.tsx
+++ b/src/components/CpuStateCard.tsx
@@ -1,0 +1,117 @@
+import React, { memo } from 'react';
+import AddressLink from './AddressLink';
+import { getDebugValueOrDefault, getNumericDebugValue } from '../utils/debug-helpers';
+import type { FilteredDebugData } from '../apple1/types/worker-messages';
+import type { WorkerManager } from '../services/WorkerManager';
+
+interface CpuStateCardProps {
+    debugInfo: FilteredDebugData;
+    workerManager?: WorkerManager;
+}
+
+// The 8-bit registers shown as a segmented rail (label above value).
+const REGISTERS: ReadonlyArray<{ label: string; field: string; def: string }> = [
+    { label: 'A', field: 'REG_A', def: '$00' },
+    { label: 'X', field: 'REG_X', def: '$00' },
+    { label: 'Y', field: 'REG_Y', def: '$00' },
+    { label: 'SP', field: 'REG_S', def: '$FF' },
+];
+
+// 6502 status bits in canonical order. `-` and `B` are placeholders (no live field) and stay dim.
+const FLAGS: ReadonlyArray<{ glyph: string; field?: string }> = [
+    { glyph: 'N', field: 'FLAG_N' },
+    { glyph: 'V', field: 'FLAG_V' },
+    { glyph: '-' },
+    { glyph: 'B' },
+    { glyph: 'D', field: 'FLAG_D' },
+    { glyph: 'I', field: 'FLAG_I' },
+    { glyph: 'Z', field: 'FLAG_Z' },
+    { glyph: 'C', field: 'FLAG_C' },
+];
+
+const flagChipClass = (state: 'set' | 'clear' | 'unused'): string => {
+    switch (state) {
+        case 'set':
+            return 'border-success bg-success/20 text-success';
+        case 'unused':
+            return 'border-border-subtle text-text-disabled';
+        default:
+            return 'border-border-primary text-text-secondary';
+    }
+};
+
+const CpuStateCardComponent: React.FC<CpuStateCardProps> = ({ debugInfo, workerManager }) => {
+    const cpu = debugInfo.cpu;
+
+    return (
+        <div className="bg-surface-primary rounded-lg p-md border border-border-primary">
+            {/* Header: title + clickable PC pill */}
+            <div className="flex items-center justify-between mb-sm">
+                <h3 className="text-sm font-medium text-text-accent">CPU State</h3>
+                <span className="inline-flex items-center gap-xs rounded-md border border-border-primary bg-data-value/5 px-sm py-xs text-xs font-mono">
+                    <span className="text-text-secondary">PC</span>
+                    {cpu?.REG_PC ? (
+                        <AddressLink
+                            address={getNumericDebugValue(cpu.REG_PC, 0)}
+                            className="font-bold"
+                            showContextMenu={true}
+                            showRunToCursor={true}
+                            {...(workerManager !== undefined ? { workerManager } : {})}
+                        />
+                    ) : (
+                        <span className="text-data-address font-bold">$0000</span>
+                    )}
+                </span>
+            </div>
+
+            {/* Register rail */}
+            <div className="grid grid-cols-4 rounded-lg border border-border-primary overflow-hidden">
+                {REGISTERS.map((reg, i) => (
+                    <div
+                        key={reg.label}
+                        className={`flex flex-col items-center gap-xs py-sm bg-surface-secondary/40 ${
+                            i > 0 ? 'border-l border-border-primary' : ''
+                        }`}
+                    >
+                        <span className="text-xs uppercase tracking-wide text-text-secondary">{reg.label}</span>
+                        <span className="text-sm font-mono font-bold text-data-value">
+                            {getDebugValueOrDefault(cpu?.[reg.field], reg.def)}
+                        </span>
+                    </div>
+                ))}
+            </div>
+
+            {/* Status flags */}
+            <div className="mt-sm">
+                <div className="text-xs tracking-wide text-text-secondary mb-xs">FLAGS</div>
+                <div className="flex gap-xs">
+                    {FLAGS.map((flag, i) => {
+                        const state = !flag.field ? 'unused' : cpu?.[flag.field] === 'SET' ? 'set' : 'clear';
+                        return (
+                            <span
+                                key={`${flag.glyph}-${i}`}
+                                className={`inline-flex items-center justify-center w-7 h-7 rounded-md border font-mono font-bold text-xs ${flagChipClass(
+                                    state,
+                                )}`}
+                            >
+                                {flag.glyph}
+                            </span>
+                        );
+                    })}
+                </div>
+            </div>
+
+            {/* Cycle counter (de-emphasized label, status-colored value) */}
+            <div className="flex items-center justify-between mt-sm pt-sm border-t border-border-subtle">
+                <span className="text-xs text-text-secondary">cycles</span>
+                <span className="text-sm font-mono text-data-status">
+                    {getDebugValueOrDefault(cpu?.HW_CYCLES, '0')}
+                </span>
+            </div>
+        </div>
+    );
+};
+
+const CpuStateCard = memo(CpuStateCardComponent);
+
+export default CpuStateCard;

--- a/src/components/CpuStateCard.tsx
+++ b/src/components/CpuStateCard.tsx
@@ -47,7 +47,7 @@ const CpuStateCardComponent: React.FC<CpuStateCardProps> = ({ debugInfo, workerM
         <div className="bg-surface-primary rounded-lg p-md border border-border-primary">
             {/* Header: title + clickable PC pill */}
             <div className="flex items-center justify-between mb-sm">
-                <h3 className="text-sm font-medium text-text-accent">CPU State</h3>
+                <h3 className="text-base font-semibold tracking-wide text-text-accent">CPU State</h3>
                 <span className="inline-flex items-center gap-xs rounded-md border border-border-primary bg-data-value/5 px-sm py-xs text-xs font-mono">
                     <span className="text-text-secondary">PC</span>
                     {cpu?.REG_PC ? (

--- a/src/components/DebuggerLayout.tsx
+++ b/src/components/DebuggerLayout.tsx
@@ -4,10 +4,12 @@ import MemoryViewerPaginated from './MemoryViewerPaginated';
 import StackViewer from './StackViewer';
 import EngineSwitcher from './EngineSwitcher';
 import PerformanceMetrics from './PerformanceMetrics';
+import CpuStateCard from './CpuStateCard';
+import ExecutionCard from './ExecutionCard';
 import { IInspectableComponent } from '../core/types';
 import { useDebuggerNavigation } from '../contexts/DebuggerNavigationContext';
 import { useWorkerData } from '../contexts/WorkerDataContext';
-import { getDebugValueOrDefault, getNumericDebugValue } from '../utils/debug-helpers';
+import { getNumericDebugValue } from '../utils/debug-helpers';
 import { useLocalStorageState } from '../hooks/useLocalStorageState';
 import AddressLink from './AddressLink';
 import type { WorkerManager } from '../services/WorkerManager';
@@ -136,152 +138,10 @@ const DebuggerLayout: React.FC<DebuggerLayoutProps> = ({
                             <EngineSwitcher workerManager={workerManager} />
 
                             {/* CPU State */}
-                            <div className="bg-surface-primary rounded-lg p-md border border-border-primary">
-                                <div className="flex items-center justify-between mb-sm">
-                                    <h3 className="text-sm font-medium text-text-accent">CPU State</h3>
-                                    <div className="text-xs font-mono text-text-secondary">
-                                        PC:{' '}
-                                        {debugInfo.cpu?.REG_PC ? (
-                                            <AddressLink
-                                                address={getNumericDebugValue(debugInfo.cpu.REG_PC, 0)}
-                                                showContextMenu={true}
-                                                workerManager={workerManager}
-                                                showRunToCursor={true}
-                                            />
-                                        ) : (
-                                            <span className="text-data-address">$0000</span>
-                                        )}
-                                    </div>
-                                </div>
-                                <div className="grid grid-cols-3 gap-sm text-sm">
-                                    <div>
-                                        <span className="text-text-secondary">A:</span>
-                                        <div className="font-mono text-data-value">
-                                            {getDebugValueOrDefault(debugInfo.cpu?.REG_A, '$00')}
-                                        </div>
-                                    </div>
-                                    <div>
-                                        <span className="text-text-secondary">X:</span>
-                                        <div className="font-mono text-data-value">
-                                            {getDebugValueOrDefault(debugInfo.cpu?.REG_X, '$00')}
-                                        </div>
-                                    </div>
-                                    <div>
-                                        <span className="text-text-secondary">Y:</span>
-                                        <div className="font-mono text-data-value">
-                                            {getDebugValueOrDefault(debugInfo.cpu?.REG_Y, '$00')}
-                                        </div>
-                                    </div>
-                                    <div>
-                                        <span className="text-text-secondary">SP:</span>
-                                        <div className="font-mono text-data-value">
-                                            {getDebugValueOrDefault(debugInfo.cpu?.REG_S, '$FF')}
-                                        </div>
-                                    </div>
-                                    <div>
-                                        <span className="text-text-secondary">Flags:</span>
-                                        <div className="font-mono text-xs space-x-1">
-                                            <span
-                                                className={
-                                                    debugInfo.cpu?.FLAG_N === 'SET'
-                                                        ? 'text-success'
-                                                        : 'text-text-secondary'
-                                                }
-                                            >
-                                                N
-                                            </span>
-                                            <span
-                                                className={
-                                                    debugInfo.cpu?.FLAG_V === 'SET'
-                                                        ? 'text-success'
-                                                        : 'text-text-secondary'
-                                                }
-                                            >
-                                                V
-                                            </span>
-                                            <span className="text-text-secondary">-</span>
-                                            <span className="text-text-secondary">B</span>
-                                            <span
-                                                className={
-                                                    debugInfo.cpu?.FLAG_D === 'SET'
-                                                        ? 'text-success'
-                                                        : 'text-text-secondary'
-                                                }
-                                            >
-                                                D
-                                            </span>
-                                            <span
-                                                className={
-                                                    debugInfo.cpu?.FLAG_I === 'SET'
-                                                        ? 'text-success'
-                                                        : 'text-text-secondary'
-                                                }
-                                            >
-                                                I
-                                            </span>
-                                            <span
-                                                className={
-                                                    debugInfo.cpu?.FLAG_Z === 'SET'
-                                                        ? 'text-success'
-                                                        : 'text-text-secondary'
-                                                }
-                                            >
-                                                Z
-                                            </span>
-                                            <span
-                                                className={
-                                                    debugInfo.cpu?.FLAG_C === 'SET'
-                                                        ? 'text-success'
-                                                        : 'text-text-secondary'
-                                                }
-                                            >
-                                                C
-                                            </span>
-                                        </div>
-                                    </div>
-                                    <div>
-                                        <span className="text-text-secondary">Cycles:</span>
-                                        <div className="font-mono text-data-status">
-                                            {getDebugValueOrDefault(debugInfo.cpu?.HW_CYCLES, '0')}
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
+                            <CpuStateCard debugInfo={debugInfo} workerManager={workerManager} />
 
                             {/* Execution State */}
-                            <div className="bg-surface-primary rounded-lg p-md border border-border-primary">
-                                <h3 className="text-sm font-medium text-text-accent mb-sm">Execution</h3>
-                                <div className="space-y-sm text-sm">
-                                    <div className="flex justify-between items-center">
-                                        <span className="text-text-secondary">Last Opcode:</span>
-                                        <span className="font-mono text-data-value">
-                                            {getDebugValueOrDefault(debugInfo.cpu?.HW_OPCODE, '$00')}
-                                        </span>
-                                    </div>
-                                    <div className="flex justify-between items-center">
-                                        <span className="text-text-secondary">Instructions:</span>
-                                        <span className="font-mono text-data-status">
-                                            {getDebugValueOrDefault(debugInfo.cpu?.PERF_INSTRUCTIONS, '0')}
-                                        </span>
-                                    </div>
-                                    <div className="flex justify-between items-center">
-                                        <span className="text-text-secondary">IRQ Line:</span>
-                                        <span
-                                            className={`font-mono text-sm ${debugInfo.cpu?.IRQ_LINE === 'ACTIVE' ? 'text-warning' : 'text-text-secondary'}`}
-                                        >
-                                            {getDebugValueOrDefault(debugInfo.cpu?.IRQ_LINE, 'INACTIVE')}
-                                        </span>
-                                    </div>
-                                    <div className="flex justify-between items-center">
-                                        <span className="text-text-secondary">NMI Line:</span>
-                                        <span
-                                            className={`font-mono text-sm ${debugInfo.cpu?.NMI_LINE === 'ACTIVE' ? 'text-warning' : 'text-text-secondary'}`}
-                                        >
-                                            {getDebugValueOrDefault(debugInfo.cpu?.NMI_LINE, 'INACTIVE')}
-                                        </span>
-                                    </div>
-                                </div>
-                            </div>
+                            <ExecutionCard debugInfo={debugInfo} />
 
                             {/* Memory Map Quick Reference */}
                             <div className="bg-surface-primary rounded-lg p-md border border-border-primary">

--- a/src/components/ExecutionCard.tsx
+++ b/src/components/ExecutionCard.tsx
@@ -1,0 +1,53 @@
+import React, { memo } from 'react';
+import { getDebugValueOrDefault } from '../utils/debug-helpers';
+import type { FilteredDebugData } from '../apple1/types/worker-messages';
+
+interface ExecutionCardProps {
+    debugInfo: FilteredDebugData;
+}
+
+const InterruptRow: React.FC<{ label: string; active: boolean }> = ({ label, active }) => (
+    <div className="flex items-center justify-between py-sm">
+        <span className="text-sm text-text-secondary">{label}</span>
+        <span className="flex items-center gap-xs">
+            <span
+                className={`inline-block w-2 h-2 rounded-full ${
+                    active ? 'bg-warning' : 'border border-text-secondary'
+                }`}
+            />
+            <span className={`font-mono text-sm ${active ? 'text-warning' : 'text-text-secondary'}`}>
+                {active ? 'ACTIVE' : 'INACTIVE'}
+            </span>
+        </span>
+    </div>
+);
+
+const ExecutionCardComponent: React.FC<ExecutionCardProps> = ({ debugInfo }) => {
+    const cpu = debugInfo.cpu;
+
+    return (
+        <div className="bg-surface-primary rounded-lg p-md border border-border-primary">
+            <h3 className="text-sm font-medium text-text-accent mb-sm">Execution</h3>
+            <div className="divide-y divide-border-subtle">
+                <div className="flex items-center justify-between py-sm">
+                    <span className="text-sm text-text-secondary">Last Opcode</span>
+                    <span className="font-mono text-sm text-data-value">
+                        {getDebugValueOrDefault(cpu?.HW_OPCODE, '$00')}
+                    </span>
+                </div>
+                <div className="flex items-center justify-between py-sm">
+                    <span className="text-sm text-text-secondary">Instructions</span>
+                    <span className="font-mono text-sm text-data-status">
+                        {getDebugValueOrDefault(cpu?.PERF_INSTRUCTIONS, '0')}
+                    </span>
+                </div>
+                <InterruptRow label="IRQ Line" active={cpu?.IRQ_LINE === 'ACTIVE'} />
+                <InterruptRow label="NMI Line" active={cpu?.NMI_LINE === 'ACTIVE'} />
+            </div>
+        </div>
+    );
+};
+
+const ExecutionCard = memo(ExecutionCardComponent);
+
+export default ExecutionCard;

--- a/src/components/ExecutionCard.tsx
+++ b/src/components/ExecutionCard.tsx
@@ -8,14 +8,14 @@ interface ExecutionCardProps {
 
 const InterruptRow: React.FC<{ label: string; active: boolean }> = ({ label, active }) => (
     <div className="flex items-center justify-between py-sm">
-        <span className="text-sm text-text-secondary">{label}</span>
+        <span className="text-xs text-text-secondary">{label}</span>
         <span className="flex items-center gap-xs">
             <span
                 className={`inline-block w-2 h-2 rounded-full ${
                     active ? 'bg-warning' : 'border border-text-secondary'
                 }`}
             />
-            <span className={`font-mono text-sm ${active ? 'text-warning' : 'text-text-secondary'}`}>
+            <span className={`font-mono text-sm font-semibold ${active ? 'text-warning' : 'text-text-secondary'}`}>
                 {active ? 'ACTIVE' : 'INACTIVE'}
             </span>
         </span>
@@ -27,17 +27,17 @@ const ExecutionCardComponent: React.FC<ExecutionCardProps> = ({ debugInfo }) => 
 
     return (
         <div className="bg-surface-primary rounded-lg p-md border border-border-primary">
-            <h3 className="text-sm font-medium text-text-accent mb-sm">Execution</h3>
+            <h3 className="text-base font-semibold tracking-wide text-text-accent mb-sm">Execution</h3>
             <div className="divide-y divide-border-subtle">
                 <div className="flex items-center justify-between py-sm">
-                    <span className="text-sm text-text-secondary">Last Opcode</span>
-                    <span className="font-mono text-sm text-data-value">
+                    <span className="text-xs text-text-secondary">Last Opcode</span>
+                    <span className="font-mono text-sm font-semibold text-data-value">
                         {getDebugValueOrDefault(cpu?.HW_OPCODE, '$00')}
                     </span>
                 </div>
                 <div className="flex items-center justify-between py-sm">
-                    <span className="text-sm text-text-secondary">Instructions</span>
-                    <span className="font-mono text-sm text-data-status">
+                    <span className="text-xs text-text-secondary">Instructions</span>
+                    <span className="font-mono text-sm font-semibold text-data-status">
                         {getDebugValueOrDefault(cpu?.PERF_INSTRUCTIONS, '0')}
                     </span>
                 </div>

--- a/src/components/__tests__/CpuStateCard-cpu-state-panel-redesign.vitest.test.tsx
+++ b/src/components/__tests__/CpuStateCard-cpu-state-panel-redesign.vitest.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import CpuStateCard from '../CpuStateCard';
+import { DebuggerNavigationProvider } from '../../contexts/DebuggerNavigationContext';
+import type { FilteredDebugData, CPUDebugData } from '../../apple1/types/worker-messages';
+
+// Build a minimal FilteredDebugData with the given cpu fields; the card only reads `.cpu`.
+const makeDebug = (cpu: CPUDebugData): FilteredDebugData => ({ cpu, pia: {}, Bus: {}, clock: {} });
+
+const renderCard = (cpu: CPUDebugData) =>
+    render(
+        <DebuggerNavigationProvider>
+            <CpuStateCard debugInfo={makeDebug(cpu)} />
+        </DebuggerNavigationProvider>,
+    );
+
+describe('CpuStateCard (cpu-state-panel-redesign)', () => {
+    it('renders the title and the A/X/Y/SP register rail with values', () => {
+        renderCard({ REG_A: '$85', REG_X: '$F2', REG_Y: '$B6', REG_S: '$AD', REG_PC: '$CC40' });
+
+        expect(screen.getByText('CPU State')).toBeInTheDocument();
+        // Rail labels
+        ['A', 'X', 'Y', 'SP'].forEach((label) => expect(screen.getByText(label)).toBeInTheDocument());
+        // Rail values
+        ['$85', '$F2', '$B6', '$AD'].forEach((v) => expect(screen.getByText(v)).toBeInTheDocument());
+    });
+
+    it('renders the PC as a clickable AddressLink button when REG_PC is present', () => {
+        renderCard({ REG_PC: '$CC40' });
+        const pc = screen.getByText('$CC40');
+        // AddressLink renders a <button>
+        expect(pc.closest('button')).not.toBeNull();
+    });
+
+    it('emphasizes SET flags with the success token and dims clear flags', () => {
+        renderCard({ FLAG_N: 'SET', FLAG_V: 'CLR', FLAG_Z: 'SET', FLAG_C: 'CLR' });
+
+        expect(screen.getByText('FLAGS')).toBeInTheDocument();
+        expect(screen.getByText('N')).toHaveClass('text-success'); // set
+        expect(screen.getByText('Z')).toHaveClass('text-success'); // set
+        expect(screen.getByText('V')).toHaveClass('text-text-secondary'); // clear
+        expect(screen.getByText('C')).toHaveClass('text-text-secondary'); // clear
+    });
+
+    it('renders the unused -/B placeholders with the disabled token (never highlighted)', () => {
+        renderCard({ FLAG_N: 'SET' });
+        expect(screen.getByText('B')).toHaveClass('text-text-disabled');
+        expect(screen.getByText('-')).toHaveClass('text-text-disabled');
+    });
+
+    it('renders the cycle counter with the status (purple) token', () => {
+        renderCard({ HW_CYCLES: '129,554,096' });
+        const cycles = screen.getByText('129,554,096');
+        expect(cycles).toHaveClass('text-data-status');
+    });
+});

--- a/src/components/__tests__/ExecutionCard-cpu-state-panel-redesign.vitest.test.tsx
+++ b/src/components/__tests__/ExecutionCard-cpu-state-panel-redesign.vitest.test.tsx
@@ -16,8 +16,9 @@ describe('ExecutionCard (cpu-state-panel-redesign)', () => {
         expect(screen.getByText('Instructions')).toBeInTheDocument();
         expect(screen.getByText('IRQ Line')).toBeInTheDocument();
         expect(screen.getByText('NMI Line')).toBeInTheDocument();
-        expect(screen.getByText('$38')).toHaveClass('text-data-value');
-        expect(screen.getByText('14,056')).toHaveClass('text-data-status');
+        // Values are emphasized (semibold) so they carry the visual hierarchy, matching the mockup.
+        expect(screen.getByText('$38')).toHaveClass('text-data-value', 'font-semibold');
+        expect(screen.getByText('14,056')).toHaveClass('text-data-status', 'font-semibold');
     });
 
     it('highlights an ACTIVE interrupt line with the warning token', () => {

--- a/src/components/__tests__/ExecutionCard-cpu-state-panel-redesign.vitest.test.tsx
+++ b/src/components/__tests__/ExecutionCard-cpu-state-panel-redesign.vitest.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ExecutionCard from '../ExecutionCard';
+import type { FilteredDebugData, CPUDebugData } from '../../apple1/types/worker-messages';
+
+const makeDebug = (cpu: CPUDebugData): FilteredDebugData => ({ cpu, pia: {}, Bus: {}, clock: {} });
+
+const renderCard = (cpu: CPUDebugData) => render(<ExecutionCard debugInfo={makeDebug(cpu)} />);
+
+describe('ExecutionCard (cpu-state-panel-redesign)', () => {
+    it('renders the title and the four execution rows with values', () => {
+        renderCard({ HW_OPCODE: '$38', PERF_INSTRUCTIONS: '14,056', IRQ_LINE: 'INACTIVE', NMI_LINE: 'INACTIVE' });
+
+        expect(screen.getByText('Execution')).toBeInTheDocument();
+        expect(screen.getByText('Last Opcode')).toBeInTheDocument();
+        expect(screen.getByText('Instructions')).toBeInTheDocument();
+        expect(screen.getByText('IRQ Line')).toBeInTheDocument();
+        expect(screen.getByText('NMI Line')).toBeInTheDocument();
+        expect(screen.getByText('$38')).toHaveClass('text-data-value');
+        expect(screen.getByText('14,056')).toHaveClass('text-data-status');
+    });
+
+    it('highlights an ACTIVE interrupt line with the warning token', () => {
+        renderCard({ IRQ_LINE: 'ACTIVE', NMI_LINE: 'INACTIVE' });
+        expect(screen.getByText('ACTIVE')).toHaveClass('text-warning');
+        expect(screen.getByText('INACTIVE')).toHaveClass('text-text-secondary');
+    });
+});

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '4.51.3';
+export const APP_VERSION = '4.51.4';


### PR DESCRIPTION
## Context

Redesign of the **CPU State** and **Execution** cards in the debugger Overview tab,
using a Claude Design–assisted mockup as the visual target. The original cards were
visually flat (labels, values, and the cycle counter all at similar weight), so nothing
guided the eye. This gives them a clear hierarchy while keeping the data contract and
design-token system intact.

## What changed

- **Extracted** the two inline cards (~146 lines) out of `DebuggerLayout.tsx` into
  prop-driven presentational components — `CpuStateCard` and `ExecutionCard` — which take
  `debugInfo` and are unit-testable in isolation. Net code is roughly flat.
- **CPU State**: segmented **A/X/Y/SP register rail** (label-over-value), a clickable
  **PC pill** (reuses `AddressLink` with context menu / run-to-cursor), a labeled
  **flag-chip strip** with distinct ON / clear / unused (`-`,`B`) states, and a
  de-emphasized purple cycle counter.
- **Execution**: divider-separated rows with a **status dot** on IRQ/NMI; prominent
  semibold title and emphasized (semibold) values so it reads as redesigned, not just
  re-bordered.
- Every value maps to an **existing design token** — zero new tokens, no hardcoded colors.

## Design decisions

- The flag section stays labeled **"FLAGS"**, not the mockup's "STATUS FLAGS":
  the **AC-7 guard test** (`DebuggerLayout-debugger-exec-bar.vitest.test.tsx`) deliberately
  forbids reusing "Status" as a label here. Honored the existing decision rather than
  reverting it.
- Titles bumped to `text-base`/semibold (closest token to the mockup's 20px); the change
  is scoped to these two cards — sibling cards (Memory Map, Stack, …) keep their current
  title size. Happy to harmonize those in a follow-up if desired.

## Verification

- `yarn test:ci` (lint + type-check + vitest): **785 passed, 1 skipped** (the WASM
  benchmark that skips in Node, as documented).
- 7 new behavioral tests for the cards (flag SET→`success`, unused→`disabled`,
  IRQ/NMI ACTIVE→`warning`, register-rail values, PC renders as a button, value emphasis).
- Verified live in-browser against the mockup (register rail, flag chips, status dots,
  typography hierarchy all match).
- Version bumped `4.51.3` → `4.51.4` (refactor → patch).

## Engine parity

UI-only change — no CPU/engine code touched, JS↔WASM parity unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CPU State card component displaying register values, flags, and cycle information in the debugger
  * Added Execution card component displaying last opcode, instruction count, and interrupt line status in the debugger

* **Tests**
  * Added comprehensive test coverage for debugger display components

* **Chores**
  * Version bumped to 4.51.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->