### PR TITLE
docs: update published address to apple1.stid.me

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ All AI-generated contributions are reviewed and curated by me to ensure quality 
 
 ## Demo
 
-You can try out the emulator in your browser with the [Interactive Demo](https://stid.me).
+You can try out the emulator in your browser with the [Interactive Demo](https://apple1.stid.me).
 
 ## Local Setup
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Apple 1 JS Emulator
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/8dda601a-c4c2-4cde-80c4-bc08ffd6d18e/deploy-status)](https://app.netlify.com/sites/stidme/deploys)
 [![CodeQL](https://github.com/stid/Apple1JS/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/stid/Apple1JS/actions/workflows/github-code-scanning/codeql)
 
 A modern TypeScript/React-based Apple 1 computer emulator featuring complete 6502 CPU emulation, memory management, peripheral interface adapter (PIA 6820), and a CRT-style display interface. Built with Vite and modern web technologies.

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '4.51.6';
+export const APP_VERSION = '4.51.7';


### PR DESCRIPTION
## What

The Apple1JS interactive demo's published address moved from `stid.me` to **https://apple1.stid.me/** (Cloudflare-hosted; DNS/infra already handled). This PR cleans up stale references to the old address.

## Changes

- **README.md** — Interactive Demo link `https://stid.me` → `https://apple1.stid.me`
- **src/version.ts** — `4.51.6` → `4.51.7` (patch bump, docs branch)

## GitHub repo metadata (done out-of-band via `gh repo edit`)

- `description` URL → `https://apple1.stid.me`
- `homepageUrl` `https://apple1-js.vercel.app` (stale Vercel deploy) → `https://apple1.stid.me/`

## Notes

- `index.html` canonical URL was already correct (updated in #188).
- No `www.stid.me` form existed anywhere.
- Lint + type-check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the interactive demo link to reference a new demo environment.

* **Chores**
  * Version updated to 4.51.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->