### PR TITLE
fix: add missing spacing.xxs token so py-xxs badges get their padding

### DIFF
--- a/src/styles/__tests__/token-tailwind-parity.vitest.test.ts
+++ b/src/styles/__tests__/token-tailwind-parity.vitest.test.ts
@@ -7,6 +7,9 @@
  * values, so the two can never drift again. The non-token-derived extras
  * (glow box-shadows, animations, keyframes) are intentionally NOT covered here.
  */
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import type { Config } from 'tailwindcss';
 import { tokenDerivedTheme } from '../tailwind-tokens';
@@ -91,5 +94,36 @@ describe('token ↔ Tailwind parity', () => {
         expect((resolved.colors?.surface as Record<string, string>)?.hover).toBe('#334155');
         expect((resolved.colors?.surface as Record<string, string>)?.sunken).toBe('#000000');
         expect((resolved.colors?.text as Record<string, string>)?.disabled).toBe('#6B7280');
+    });
+
+    // `py-xxs` was used by four components before `spacing.xxs` existed; Tailwind
+    // silently emitted no CSS for it (zero vertical padding on badges).
+    it('exposes the spacing.xxs repair token', () => {
+        expect(tokenDerivedTheme.spacing.xxs, 'spacing.xxs').toBe('0.125rem');
+        expect(resolved.spacing?.xxs).toBe('0.125rem');
+    });
+
+    // Reverse guard: every named spacing suffix a component uses must be a token.
+    // Tailwind's JIT drops unknown utilities without warning, so a typo or a
+    // missing token is invisible to the build and only shows up as broken layout.
+    it('every named spacing class used in components resolves to a token', () => {
+        const tokenKeys = new Set(Object.keys(tokenDerivedTheme.spacing));
+        const builtin = new Set(['auto', 'px']);
+        const classPattern = /(?<![\w-])-?(?:p|px|py|pt|pb|pl|pr|m|mx|my|mt|mb|ml|mr|gap|gap-x|gap-y|space-x|space-y)-([a-z]+)(?![\w-])/g;
+        const componentsDir = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'components');
+        const files = readdirSync(componentsDir, { recursive: true, encoding: 'utf8' }).filter(
+            (f) => f.endsWith('.tsx') && !f.includes('__tests__')
+        );
+        const unknown = new Set<string>();
+        for (const file of files) {
+            const source = readFileSync(join(componentsDir, file), 'utf8');
+            for (const match of source.matchAll(classPattern)) {
+                const suffix = match[1];
+                if (!tokenKeys.has(suffix) && !builtin.has(suffix)) {
+                    unknown.add(`${file}: ${match[0]}`);
+                }
+            }
+        }
+        expect([...unknown]).toEqual([]);
     });
 });

--- a/src/styles/tokens.ts
+++ b/src/styles/tokens.ts
@@ -134,6 +134,7 @@ export const designTokens = {
 
     // Spacing system - consistent spacing scale
     spacing: {
+        xxs: '0.125rem', // 2px
         xs: '0.25rem', // 4px
         sm: '0.5rem', // 8px
         md: '1rem', // 16px

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '4.51.9';
+export const APP_VERSION = '4.51.10';


### PR DESCRIPTION
## Summary

- `py-xxs` was used by four components but `spacing.xxs` never existed in `tokens.ts`, so Tailwind emitted no CSS and those badges rendered with zero vertical padding
- adds `spacing.xxs = 0.125rem` (flows to Tailwind via the existing adapter)
- adds a reverse parity guard: scans component classNames for padding/margin/gap/space utilities with a named suffix and asserts each maps to a real token. The existing parity test only guarded token→config; this closes the component→token direction
- version 4.51.9 → 4.51.10

## Test plan

- [x] new tests fail on master (both name the four `py-xxs` files), pass with the token added
- [x] `yarn test:ci` green: 792 passed, 21 skipped
- [x] lint + type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDq6at6VpsyBxLqB8wBnDT